### PR TITLE
Support for Google API Premier V2

### DIFF
--- a/lib/geokit/geocoders.rb
+++ b/lib/geokit/geocoders.rb
@@ -430,7 +430,10 @@ module Geokit
       def self.do_geocode(address, options = {})
         bias_str = options[:bias] ? construct_bias_string_from_options(options[:bias]) : ''
         address_str = address.is_a?(GeoLoc) ? address.to_geocodeable_s : address
-        res = self.call_geocoder_service("http://maps.google.com/maps/geo?q=#{Geokit::Inflector::url_escape(address_str)}&output=xml#{bias_str}&key=#{Geokit::Geocoders::google}&oe=utf-8")
+        # API premier expects the client param that always begins with gme-, whereas free maps expect the key param
+        key_param = (Geokit::Geocoders::google =~ /^gme-/) ? 'client' : 'key'
+        res = self.call_geocoder_service("http://maps.google.com/maps/geo?q=#{Geokit::Inflector::url_escape(address_str)}&output=xml#{bias_str}&#{key_param}=#{Geokit::Geocoders::google}&oe=utf-8")
+
         return GeoLoc.new if !res.is_a?(Net::HTTPSuccess)
         xml = res.body
         logger.debug "Google geocoding. Address: #{address}. Result: #{xml}"

--- a/test/test_google_geocoder.rb
+++ b/test/test_google_geocoder.rb
@@ -1,7 +1,5 @@
 require File.join(File.dirname(__FILE__), 'test_base_geocoder')
 
-Geokit::Geocoders::google = 'Google'
-
 class GoogleGeocoderTest < BaseGeocoderTest #:nodoc: all
   
   GOOGLE_FULL=<<-EOF.strip
@@ -39,6 +37,8 @@ class GoogleGeocoderTest < BaseGeocoderTest #:nodoc: all
 
     @google_full_loc = Geokit::GeoLoc.new(@google_full_hash)
     @google_city_loc = Geokit::GeoLoc.new(@google_city_hash)
+
+    Geokit::Geocoders::google = 'Google'
   end  
 
   def test_google_full_address
@@ -100,6 +100,15 @@ class GoogleGeocoderTest < BaseGeocoderTest #:nodoc: all
     Geokit::Geocoders::GoogleGeocoder.expects(:call_geocoder_service).with(url).returns(response)
     res=Geokit::Geocoders::GoogleGeocoder.geocode(@address)
     assert_equal 4, res.accuracy
+  end
+  
+  def test_google_with_api_premier_key
+    Geokit::Geocoders::google = 'gme-test' # enterprise keys begin with 'gme-'
+    response = MockSuccess.new
+    response.expects(:body).returns(GOOGLE_CITY)
+    url = "http://maps.google.com/maps/geo?q=#{Geokit::Inflector.url_escape(@address)}&output=xml&client=gme-test&oe=utf-8"
+    Geokit::Geocoders::GoogleGeocoder.expects(:call_geocoder_service).with(url).returns(response)
+    Geokit::Geocoders::GoogleGeocoder.geocode(@address)
   end
   
   def test_google_city_with_geo_loc


### PR DESCRIPTION
Hello Andre,

would you like to incorporate this tweak ? It's allowing users to support the API Premier in V2.

I will probably be working on adding more V3 geocoding (with Premier support as I need it for a customer) later on.

If there is any issue with the patch itself, please tell me so I can adjust it!

best,

-- Thibaut
