### PR TITLE
Let any object responding to :to_lat_lng include GeoKit::Mappable

### DIFF
--- a/lib/geokit/mappable.rb
+++ b/lib/geokit/mappable.rb
@@ -287,6 +287,8 @@ module Geokit
         return thing
       elsif thing.class.respond_to?(:acts_as_mappable) && thing.class.respond_to?(:distance_column_name)
         return thing.to_lat_lng
+      elsif thing.respond_to? :to_lat_lng
+        return thing.to_lat_lng
       end
       
       raise ArgumentError.new("#{thing} (#{thing.class}) cannot be normalized to a LatLng. We tried interpreting it as an array, string, Mappable, etc., but no dice.")


### PR DESCRIPTION
I would like to be able to use Geokit::Mappable without having to acts_as_mappable which is highly tied to ActiveRecord.

That would enable to do this :

  include GeoKit::Mappable

  def to_lat_lng
    GeoKit::LatLng.new(location[0], location[1])
  end

In non ActiveRecord classes.
