### PR TITLE
do_get now supports basic auth so the authenticated geocoder.us service works again

### DIFF
--- a/lib/geokit/geocoders.rb
+++ b/lib/geokit/geocoders.rb
@@ -170,10 +170,12 @@ module Geokit
         uri = URI.parse(url)
         req = Net::HTTP::Get.new(url)
         req.basic_auth(uri.user, uri.password) if uri.userinfo
-        res = Net::HTTP::Proxy(GeoKit::Geocoders::proxy_addr,
+
+        http_class = Net::HTTP::Proxy(GeoKit::Geocoders::proxy_addr,
                 GeoKit::Geocoders::proxy_port,
                 GeoKit::Geocoders::proxy_user,
-                GeoKit::Geocoders::proxy_pass).start(uri.host, uri.port) { |http| http.get(uri.path + "?" + uri.query) }
+                GeoKit::Geocoders::proxy_pass)
+        res = http_class.new(uri.host, uri.port).start { |http| http.request(req) }
         return res
       end
       


### PR DESCRIPTION
I saw that the http get request that was being created earlier in the method never got passed to the HTTP request object. I fixed the code so it now properly supports proxies as well as basic auth.
