### PR TITLE
Fix for addresses with umlauts

### DIFF
--- a/lib/geokit/geocoders.rb
+++ b/lib/geokit/geocoders.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require 'net/http'
 require 'ipaddr'
 require 'rexml/document'
@@ -44,9 +46,10 @@ module Geokit
     end
     
     def url_escape(s)
-    s.gsub(/([^ a-zA-Z0-9_.-]+)/nu) do
-      '%' + $1.unpack('H2' * $1.size).join('%').upcase
-      end.tr(' ', '+')
+      parser = URI::Parser.new
+
+      # The gsub part will make the result compatible with the old tests
+      parser.escape(s).gsub('%20', '+')
     end
     
     def camelize(str)
@@ -440,8 +443,8 @@ module Geokit
         res = self.call_geocoder_service("http://maps.google.com/maps/geo?q=#{Geokit::Inflector::url_escape(address_str)}&output=xml#{bias_str}&key=#{Geokit::Geocoders::google}&oe=utf-8")
         return GeoLoc.new if !res.is_a?(Net::HTTPSuccess)
         xml = res.body
-        logger.debug "Google geocoding. Address: #{address}. Result: #{xml}"
-        return self.xml2GeoLoc(xml, address)        
+        logger.debug "Google geocoding. Address: #{address}. Result: #{xml.encode("UTF-8")}"
+        return self.xml2GeoLoc(xml, address)
       end
       
       def self.construct_bias_string_from_options(bias)

--- a/test/test_base_geocoder.rb
+++ b/test/test_base_geocoder.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require 'test/unit'
 require 'net/http'
 require 'rubygems'
@@ -28,7 +30,8 @@ class BaseGeocoderTest < Test::Unit::TestCase #:nodoc: all
     @address = 'San Francisco, CA'    
     @full_address = '100 Spear St, San Francisco, CA, 94105-1522, US'   
     @full_address_short_zip = '100 Spear St, San Francisco, CA, 94105, US' 
-    
+    @full_address_umlauts = 'Maschmühlenweg 99, Göttingen, Germany'
+
     @latlng = Geokit::LatLng.new(37.7742, -122.417068)
     @success = Geokit::GeoLoc.new({:city=>"SAN FRANCISCO", :state=>"CA", :country_code=>"US", :lat=>@latlng.lat, :lng=>@latlng.lng})
     @success.success = true    

--- a/test/test_inflector.rb
+++ b/test/test_inflector.rb
@@ -21,4 +21,8 @@ class InflectorTest < Test::Unit::TestCase #:nodoc: all
     assert_equal 'Borås (Abc)', Geokit::Inflector.titleize('borås (abc)')
   end
    
+  def test_url_escape_with_umlauts
+    assert_equal '%C3%BC%C3%B6%C3%A4', Geokit::Inflector.url_escape('üöä')
+  end
+
 end


### PR DESCRIPTION
Hi Andre,

i had a problem with the GoogleGeocoder and addresses that contained umlauts.

There is also an open ticket for that: #7

The pull request contains:
- fix for addresses with umlauts 
- test "test_url_escape_with_umlauts" and "test_address_with_umlauts" added

Enrico
