### PR TITLE
Using json instead of json_pure

### DIFF
--- a/geokit.gemspec
+++ b/geokit.gemspec
@@ -34,5 +34,5 @@ Gem::Specification.new do |s|
     current_version = Gem::Specification::CURRENT_SPECIFICATION_VERSION
     s.specification_version = 2
   end
-  s.add_dependency(%q{json_pure})
+  s.add_dependency(%q{json})
 end

--- a/lib/geokit/geocoders.rb
+++ b/lib/geokit/geocoders.rb
@@ -9,7 +9,7 @@ require 'logger'
 begin 
   ActiveSupport.nil?
 rescue NameError
-  require 'json/pure'
+  require 'json'
 end
 
 module Geokit


### PR DESCRIPTION
For better performance and compatibility.

`[1].to_json` in json_pure = exception.

Also, modern version of ActiveSupport loads json gem by default instead of json_pure
