### PR TITLE
Fix for missing viewport in GoogleGeocoder3 response; utf-8 encoding fix

### DIFF
--- a/lib/geokit/geocoders.rb
+++ b/lib/geokit/geocoders.rb
@@ -175,7 +175,7 @@ module Geokit
         res = Net::HTTP::Proxy(GeoKit::Geocoders::proxy_addr,
                 GeoKit::Geocoders::proxy_port,
                 GeoKit::Geocoders::proxy_user,
-                GeoKit::Geocoders::proxy_pass).start(uri.host, uri.port) { |http| http.get(uri.path + "?" + uri.query) }
+                GeoKit::Geocoders::proxy_pass).start(uri.host, uri.port) { |http| http.get( [uri.path, uri.query].compact.join('?') ) }
         return res
       end
       


### PR DESCRIPTION
`GoogleGeocoder3` was failing with a nil because Goog v3 API does not always return the `viewport` coordinates structure. This seemed to be the case regardless of whether a bias bounds was passed or not. This fix simply checks before trying to decode the viewport coordinates.  Also show the entire request string for the log to facilitate debugging.

This edit also rolls up #7 and #26 fixes for utf-8 encoding of the response, which was another error we were seeing when passing in address strings that are utf-8 encoded.
