### PR TITLE
handling of UTF8 encodings for GoogleGeocoder3

### DIFF
--- a/lib/geokit/geocoders.rb
+++ b/lib/geokit/geocoders.rb
@@ -568,13 +568,14 @@ module Geokit
       def self.do_geocode(address, options = {})
         bias_str = options[:bias] ? construct_bias_string_from_options(options[:bias]) : ''
         address_str = address.is_a?(GeoLoc) ? address.to_geocodeable_s : address
-        res = self.call_geocoder_service("http://maps.google.com/maps/api/geocode/json?sensor=false&address=#{Geokit::Inflector::url_escape(address_str)}#{bias_str}")
+        url ="http://maps.google.com/maps/api/geocode/json?sensor=false&address=#{CGI.escape(address_str)}#{bias_str}"
+        res = self.call_geocoder_service(url)
         return GeoLoc.new if !res.is_a?(Net::HTTPSuccess)
         json = res.body
-        logger.debug "Google geocoding. Address: #{address}. Result: #{json}"
-        return self.json2GeoLoc(json, address)        
+        logger.debug "Google geocoding. Address: #{address}. Result: #{CGI.escape(json)}"
+        return self.json2GeoLoc(json, address)
       end
- 
+
       def self.construct_bias_string_from_options(bias)
         if bias.is_a?(String) or bias.is_a?(Symbol)
           # country code biasing


### PR DESCRIPTION
http://stackoverflow.com/questions/3493290/geokit-gem-1-5-and-ruby-1-9-2-incompatible-character-encodings-utf-8-and-asc/7263606#7263606
