### PR TITLE
Correctly checks for response codes not equal to 'OK' for GoogleGecoder3

### DIFF
--- a/lib/geokit/services/google3.rb
+++ b/lib/geokit/services/google3.rb
@@ -72,7 +72,7 @@ module Geokit
           return GeoLoc.new
         end
         # this should probably be smarter.
-        if !results['status'] == 'OK'
+        if results['status'] != 'OK'
           raise Geokit::Geocoders::GeocodeError
         end
         # location_type stores additional data about the specified location.

--- a/test/test_google_geocoder3.rb
+++ b/test/test_google_geocoder3.rb
@@ -372,6 +372,12 @@ class GoogleGeocoder3Test < BaseGeocoderTest #:nodoc: all
        "status": "OVER_QUERY_LIMIT"
     }
   /
+  GOOGLE3_INVALID_REQUEST=%q/
+  {
+    "results" : [],
+    "status" : "INVALID_REQUEST"
+  }
+  /
   def setup
     super
     @full_address = '100 Spear St Apt. 5, San Francisco, CA, 94105-1522, US'
@@ -551,6 +557,16 @@ puts res.to_hash.inspect
      url = "http://maps.google.com/maps/api/geocode/json?sensor=false&address=#{Geokit::Inflector.url_escape(@address)}"
      Geokit::Geocoders::GoogleGeocoder3.expects(:call_geocoder_service).with(url).returns(response)
      assert_raise Geokit::TooManyQueriesError do
+       res=Geokit::Geocoders::GoogleGeocoder3.geocode(@address)
+     end
+   end
+
+   def test_invalid_request
+     response = MockSuccess.new
+     response.expects(:body).returns(GOOGLE3_INVALID_REQUEST)
+     url = "http://maps.google.com/maps/api/geocode/json?sensor=false&address=#{Geokit::Inflector.url_escape("3961 V\u00EDa Marisol")}"
+     Geokit::Geocoders::GoogleGeocoder3.expects(:call_geocoder_service).with(url).returns(response)
+     assert_raise Geokit::Geocoders::GeocodeError do
        res=Geokit::Geocoders::GoogleGeocoder3.geocode(@address)
      end
    end


### PR DESCRIPTION
`!results['status'] == 'OK'` is not the same as `!(results['status'] == 'OK')` or `results['status'] != 'OK'`

I added a test but I could not get the test to run so I have no ran it.
