### PR TITLE
Show the rescued exception name during MultiGeocoder geocoding

### DIFF
--- a/lib/geokit/multi_geocoder.rb
+++ b/lib/geokit/multi_geocoder.rb
@@ -31,8 +31,8 @@ module Geokit
             klass = Geokit::Geocoders.const_get "#{Geokit::Inflector::camelize(provider.to_s)}Geocoder"
             res = klass.send :geocode, address, options
             return res if res.success?
-          rescue
-            logger.error("Something has gone very wrong during geocoding, OR you have configured an invalid class name in Geokit::Geocoders::provider_order. Address: #{address}. Provider: #{provider}")
+          rescue => e
+            logger.error("An error has occurred during geocoding: #{e}\nAddress: #{address}. Provider: #{provider}")
           end
         end
         # If we get here, we failed completely.
@@ -48,8 +48,8 @@ module Geokit
             klass = Geokit::Geocoders.const_get "#{Geokit::Inflector::camelize(provider.to_s)}Geocoder"
             res = klass.send :reverse_geocode, latlng
             return res if res.success?
-          rescue
-            logger.error("Something has gone very wrong during reverse geocoding, OR you have configured an invalid class name in Geokit::Geocoders::provider_order. LatLng: #{latlng}. Provider: #{provider}")
+          rescue => e
+            logger.error("An error has occurred during geocoding: #{e}\nAddress: #{address}. Provider: #{provider}")
           end
         end
         # If we get here, we failed completely.


### PR DESCRIPTION
Since we're rescuing all exceptions here, it seems to make sense to show the exception name.
