### PR TITLE
Adding Geokit::Polygon class to mappable.rb

### DIFF
--- a/geokit.gemspec
+++ b/geokit.gemspec
@@ -17,12 +17,13 @@ Gem::Specification.new do |s|
   s.has_rdoc = true
   s.rdoc_options = ["--main", "README.markdown"]
   s.extra_rdoc_files = ["README.markdown"]
-
-  s.files = ["README.markdown", "Rakefile", "lib/geokit/geocoders.rb", "lib/geokit.rb",
-    "lib/geokit/mappable.rb", "test/test_base_geocoder.rb", "test/test_bounds.rb",
-    "test/test_ca_geocoder.rb", "test/test_geoloc.rb", "test/test_google_geocoder3.rb",
-    "test/test_google_geocoder.rb", "test/test_latlng.rb", "test/test_multi_geocoder.rb",
-    "test/test_us_geocoder.rb", "test/test_yahoo_geocoder.rb"
+    
+  s.files = [
+    "README.markdown", "Rakefile",  "lib/geokit.rb", "lib/geokit/geocoders.rb", "lib/geokit/inflectors.rb", 
+    "lib/geokit/mappable.rb", "lib/geokit/multi_geocoder.rb", "lib/geokit/services/ca_geocoder.rb", 
+    "lib/geokit/services/fcc.rb", "lib/geokit/services/geo_plugin.rb", "lib/geokit/services/geonames.rb", 
+    "lib/geokit/services/google.rb", "lib/geokit/services/google3.rb", "lib/geokit/services/ip.rb", 
+    "lib/geokit/services/us_geocoder.rb", "lib/geokit/services/yahoo.rb", "lib/geokit/version.rb"
   ]
 
   s.test_files = [

--- a/lib/geokit/mappable.rb
+++ b/lib/geokit/mappable.rb
@@ -553,13 +553,21 @@ module Geokit
     
     def initialize(points)
       # Pass in an array of Geokit::LatLng
-      @poly_y = []
       @poly_x = []
+      @poly_y = []
 
       points.each do |point|
         @poly_x << point.lng
         @poly_y << point.lat
       end
+      
+      # A Polygon must be 'closed', the last point equal to the first point
+      if not @poly_x[0] == @poly_x[-1] or not @poly_y[0] == @poly_y[-1]
+        # Append the first point to the array to close the polygon
+        @poly_x << @poly_x[0]
+        @poly_y << @poly_y[0]
+      end
+      
     end
 
     def contains?(point)

--- a/test/test_polygon_contains.rb
+++ b/test/test_polygon_contains.rb
@@ -44,6 +44,15 @@ class PolygonTest < Test::Unit::TestCase #:nodoc: all
     @complex_outside_two = Geokit::LatLng.new(45.30435378077673, -93.6859130859375)
     @complex_outside_three = Geokit::LatLng.new(45.538820010517036, -93.486946108751)
 
+    # Test open sided polygon aka line - for closing on initialize
+    @op1 = Geokit::LatLng.new(44.97402795596173, -92.7297592163086)
+    @op2 = Geokit::LatLng.new(44.97395509241393, -92.68448066781275)
+    @op3 = Geokit::LatLng.new(44.94455954512172, -92.68413734505884)
+    @op4 = Geokit::LatLng.new(44.94383053857761, -92.72876930306666)
+
+    @open_points = [@op1, @op2, @op3, @op4]
+    @open_polygon = Geokit::Polygon.new(@open_points)
+
   end  
 
   def test_point_inside_poly
@@ -74,6 +83,19 @@ class PolygonTest < Test::Unit::TestCase #:nodoc: all
     assert !@complex_polygon.contains?(@complex_outside_one)
     assert !@complex_polygon.contains?(@complex_outside_two) 
     assert !@complex_polygon.contains?(@complex_outside_three)     
+  end
+  
+  def test_open_polygon
+    # A polygon can only exist of the last point is equal to the first
+    # Otherwise, it would just be a line of points.
+
+    #puts "\n\nTesting intialize function to close an open polygon..."
+    #puts "\t Does poly_x[0] (#{@open_polygon.poly_x[0]}) == poly_x[-1] (#{@open_polygon.poly_x[-1]}) ?"
+    #puts "\t Does poly_y[0] (#{@open_polygon.poly_y[0]}) == poly_y[-1] (#{@open_polygon.poly_y[-1]}) ?"
+    
+    assert @open_polygon.poly_x[0] == @open_polygon.poly_x[-1]
+    assert @open_polygon.poly_y[0] == @open_polygon.poly_y[-1]
+    
   end
 
 end


### PR DESCRIPTION
Creates a Polygon class, usage example:

```
p1 = Geokit::LatLng.new(45.3142533036254, -93.47527313511819)
p2 = Geokit::LatLng.new(45.31232182518015, -93.34893036168069)
p3 = Geokit::LatLng.new(45.23694281999268, -93.35167694371194)
p4 = Geokit::LatLng.new(45.23500870841669, -93.47801971714944)
p5 = Geokit::LatLng.new(45.3142533036254, -93.47527313511819)

points = [p1, p2, p3, p4, p5]
polygon = Geokit::Polygon.new(points)

point_inside = Geokit::LatLng.new(45.27428243796789, -93.41648483416066)
point_outside = Geokit::LatLng.new(45.45411010558687, -93.78151703160256)

polygon.contains?(point_inside) => true
polygon.contains?(point_outside) => false  
```
