### PR TITLE
Make geokit compatible with 1.9

### DIFF
--- a/lib/geokit/mappable.rb
+++ b/lib/geokit/mappable.rb
@@ -46,7 +46,7 @@ module Geokit
                 Math.acos( Math.sin(deg2rad(from.lat)) * Math.sin(deg2rad(to.lat)) +
                 Math.cos(deg2rad(from.lat)) * Math.cos(deg2rad(to.lat)) *
                 Math.cos(deg2rad(to.lng) - deg2rad(from.lng)))
-          rescue Errno::EDOM
+          rescue Errno::EDOM, Math::DomainError
             0.0
           end
         when :flat


### PR DESCRIPTION
This fixes a problem when running on ruby 1.9.3. Apparently ruby 1.9 returns a different error for invalid input to acos than ruby 1.8.
