### PR TITLE
fix for changed yahoo json results

### DIFF
--- a/lib/geokit/services/yahoo.rb
+++ b/lib/geokit/services/yahoo.rb
@@ -22,7 +22,7 @@ module Geokit
 
         if results['ResultSet']['Error'] == '0' && results['ResultSet']['Result'] != nil
           geoloc = nil
-          extracted_geoloc = extract_geoloc(results['Results']['Result'])
+          extracted_geoloc = extract_geoloc(results['ResultSet']['Result'])
           if geoloc.nil?
             geoloc = extracted_geoloc
           else


### PR DESCRIPTION
apparently yahoo placefinder changed their json results

['ResultSet']['Error'] is now a string value
['ResultSet']['Results'] has no become ['ResultSet']['Result'] and value has changed from array to hash.

This commit fixes that issue.  I did not change any tests.
