### PR TITLE
ipgecoder handles non-utf8 character sets; fixed tests

### DIFF
--- a/lib/geokit/mappable.rb
+++ b/lib/geokit/mappable.rb
@@ -443,7 +443,7 @@ module Geokit
     end
 
     def to_yaml_properties
-      (instance_variables - ['@all']).sort
+      (instance_variables - ['@all', :@all]).sort
     end
 
     # Returns a string representation of the instance.

--- a/lib/geokit/multi_geocoder.rb
+++ b/lib/geokit/multi_geocoder.rb
@@ -49,7 +49,7 @@ module Geokit
             res = klass.send :reverse_geocode, latlng
             return res if res.success?
           rescue => e
-            logger.error("An error has occurred during geocoding: #{e}\nAddress: #{address}. Provider: #{provider}")
+            logger.error("An error has occurred during geocoding: #{e}\nLatlng: #{latlng}. Provider: #{provider}")
           end
         end
         # If we get here, we failed completely.

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -9,11 +9,13 @@ require File.join(File.dirname(__FILE__), "../lib/geokit.rb")
 
 class MockSuccess < Net::HTTPSuccess #:nodoc: all
   def initialize
+    @header = {}
   end
 end
 
 class MockFailure < Net::HTTPServiceUnavailable #:nodoc: all
   def initialize
+    @header = {}
   end
 end
 

--- a/test/test_geoloc.rb
+++ b/test/test_geoloc.rb
@@ -64,7 +64,7 @@ class GeoLocTest < Test::Unit::TestCase #:nodoc: all
     @loc.zip = '94105'
     @loc.country_code = 'US'
     assert_equal(
-      "--- !ruby/object:Geokit::GeoLoc \ncity: San Francisco\ncountry_code: US\nfull_address: \nlat: \nlng: \nprecision: unknown\nprovince: \nstate: CA\nstreet_address: \nstreet_name: \nstreet_number: \nsub_premise: \nsuccess: false\nzip: \"94105\"\n",
+      "--- !ruby/object:Geokit::GeoLoc\ncity: San Francisco\ncountry_code: US\nfull_address: \nlat: \nlng: \nprecision: unknown\nprovince: \nstate: CA\nstreet_address: \nstreet_name: \nstreet_number: \nsub_premise: \nsuccess: false\nzip: \'94105\'\n",
       @loc.to_yaml)
   end
 

--- a/test/test_google_geocoder.rb
+++ b/test/test_google_geocoder.rb
@@ -227,7 +227,7 @@ class GoogleGeocoderTest < BaseGeocoderTest #:nodoc: all
     response = MockSuccess.new
     response.expects(:body).returns(GOOGLE_BOUNDS_BIASED_RESULT)
 
-    url = "http://maps.google.com/maps/geo?q=Winnetka&output=xml&ll=34.197693208849,-118.547160027785&spn=0.247047999999999,0.294914000000006&key=Google&oe=utf-8"
+    url = "http://maps.google.com/maps/geo?q=Winnetka&output=xml&ll=34.19769320884902,-118.54716002778494&spn=0.2470479999999995,0.29491400000000567&key=Google&oe=utf-8"
     Geokit::Geocoders::GoogleGeocoder.expects(:call_geocoder_service).with(url).returns(response)
 
     bounds = Geokit::Bounds.normalize([34.074081, -118.694401], [34.321129, -118.399487])

--- a/test/test_google_geocoder3.rb
+++ b/test/test_google_geocoder3.rb
@@ -428,7 +428,6 @@ class GoogleGeocoder3Test < BaseGeocoderTest #:nodoc: all
      Geokit::Geocoders::GoogleGeocoder3.expects(:call_geocoder_service).with(url).returns(response)
      res=Geokit::Geocoders::GoogleGeocoder3.geocode(@google_full_loc)
 
-puts res.to_hash.inspect
      assert_equal 9, res.accuracy
    end
 
@@ -479,7 +478,7 @@ puts res.to_hash.inspect
      res = Geokit::Geocoders::GoogleGeocoder3.geocode(@google_full_loc)
 
      assert_instance_of Geokit::Bounds, res.suggested_bounds
-     assert_equal Geokit::Bounds.new(Geokit::LatLng.new(37.7908019197085, -122.395348980292), Geokit::LatLng.new(37.7934998802915, -122.392651019708)), res.suggested_bounds
+     assert_equal Geokit::Bounds.new(Geokit::LatLng.new(37.7908019197085, -122.3953489802915), Geokit::LatLng.new(37.7934998802915, -122.3926510197085)), res.suggested_bounds
    end
 
    def test_service_unavailable
@@ -571,7 +570,7 @@ puts res.to_hash.inspect
      url = "http://maps.google.com/maps/api/geocode/json?sensor=false&address=#{Geokit::Inflector.url_escape("3961 V\u00EDa Marisol")}"
      Geokit::Geocoders::GoogleGeocoder3.expects(:call_geocoder_service).with(url).returns(response)
      assert_raise Geokit::Geocoders::GeocodeError do
-       res=Geokit::Geocoders::GoogleGeocoder3.geocode(@address)
+       Geokit::Geocoders::GoogleGeocoder3.geocode("3961 V\u00EDa Marisol")
      end
    end
 end


### PR DESCRIPTION
In the ipgeocoder the provider hostip.info sometimes returns responses that are encoded in Latin-1, however Ruby thinks it's UTF-8. This is incompatible with Rails 3 (and others?) and will error in psych yaml library.

To reproduce this, simply try to geocode ip of 201.23.177.144
This was tested in ruby 1.9.3-p194

This pull request looks at the headers and forces the right encoding, then encodes it to UTF-8. I've wrote tests for this case. Also I fixed other tests that were failing.
