### PR TITLE
Support Ruby 1.8 and 1.9 in mappable.rb

### DIFF
--- a/lib/geokit/mappable.rb
+++ b/lib/geokit/mappable.rb
@@ -41,12 +41,18 @@ module Geokit
         formula = options[:formula] || Geokit::default_formula
         case formula
         when :sphere
+          error_classes = [Errno::EDOM]
+
+          # Ruby 1.9 raises {Math::DomainError}, but it is not defined in Ruby
+          # 1.8. Backwards-compatibly rescue both errors.
+          error_classes << Math::DomainError if defined?(Math::DomainError)
+
           begin
             units_sphere_multiplier(units) *
                 Math.acos( Math.sin(deg2rad(from.lat)) * Math.sin(deg2rad(to.lat)) +
                 Math.cos(deg2rad(from.lat)) * Math.cos(deg2rad(to.lat)) *
                 Math.cos(deg2rad(to.lng) - deg2rad(from.lng)))
-          rescue Errno::EDOM, Math::DomainError
+          rescue *error_classes
             0.0
           end
         when :flat


### PR DESCRIPTION
This preserves backwards compatibility with Ruby 1.8 since [`Math::DomainError`](http://www.ruby-doc.org/core-1.9.3/Math/DomainError.html) was added in 1.9. If the rescue block is run in 1.8, it raises `NameError: uninitialized constant Math::DomainError`.

The commit that started rescuing the 1.9-only error class: https://github.com/imajes/geokit/commit/952f2966090261322105687a80ad75426a03d852
