### PR TITLE
Yahoo sometimes returns [nil] result, even if no error is listed

### DIFF
--- a/lib/geokit/services/yahoo.rb
+++ b/lib/geokit/services/yahoo.rb
@@ -20,7 +20,7 @@ module Geokit
       def self.json2GeoLoc(json, address)
         results = MultiJson.load(json)
 
-        if results['ResultSet']['Error'] == 0 && results['ResultSet']['Results'] != nil
+        if results['ResultSet']['Error'] == 0 && results['ResultSet']['Results'] != nil && results['ResultSet']['Results'].first != nil
           geoloc = nil
           results['ResultSet']['Results'].each do |result|
             extracted_geoloc = extract_geoloc(result)


### PR DESCRIPTION
{"ResultSet"=>{"Quality"=>0, "Results"=>[nil], "Locale"=>"US", "Found"=>1, "version"=>"1.0", "ErrorMessage"=>"No error", "Error"=>0}}
