### PR TITLE
Bugfix Us geocoder

### DIFF
--- a/lib/geokit/services/us_geocoder.rb
+++ b/lib/geokit/services/us_geocoder.rb
@@ -41,7 +41,7 @@ module Geokit
           return GeoLoc.new
         end
         rescue
-          logger.error "Caught an error during geocoder.us geocoding call: "+$!
+          logger.error "Caught an error during geocoder.us geocoding call: "+$!.inspect
           return GeoLoc.new
 
       end


### PR DESCRIPTION
``` ruby
GeoKit::Geocoders::UsGeocoder.geocode("sf")
```

Produces:

```
TypeError: can't convert TypeError into String
from /home/bogdan/.rvm/gems/ruby-1.9.3-p194/bundler/gems/geokit-e712f0a7b21a/lib/geokit/services/us_geocoder.rb:44:in `+'
```

I believe this line never worked well.
