### PR TITLE
fixing comparison to number (should be string)

### DIFF
--- a/lib/geokit/services/yahoo.rb
+++ b/lib/geokit/services/yahoo.rb
@@ -20,7 +20,7 @@ module Geokit
       def self.json2GeoLoc(json, address)
         results = MultiJson.load(json)
 
-        if results['ResultSet']['Error'] == 0 && results['ResultSet']['Results'] != nil && results['ResultSet']['Results'].first != nil
+        if results['ResultSet']['Error'] == "0" && results['ResultSet']['Results'] != nil && results['ResultSet']['Results'].first != nil
           geoloc = nil
           results['ResultSet']['Results'].each do |result|
             extracted_geoloc = extract_geoloc(result)


### PR DESCRIPTION
Yahoo geolocation appears not to work at all because of a comparison that is expecting a numeric 0 when in fact the result is a string.

As-is, I am unable to geolocate any response from Yahoo whatsoever, consistently getting the error "Yahoo was unable to geocode address:" 

this commit fixes the problem for me. 
