### PR TITLE
Adds escape to prevent logger from choking on character enncoding in Google3 geocoder.

### DIFF
--- a/lib/geokit/services/google3.rb
+++ b/lib/geokit/services/google3.rb
@@ -60,7 +60,7 @@ module Geokit
         return GeoLoc.new if !res.is_a?(Net::HTTPSuccess)
 
         json = res.body
-        logger.debug "Google geocoding. Address: #{address}. Result: #{json}"
+        logger.debug "Google geocoding. Address: #{address}. Result: #{CGI.escape(json)}"
 
         return self.json2GeoLoc(json, address)
       end


### PR DESCRIPTION
This fix the follow error:

```
An Encoding::CompatibilityError occurred in registrations#update:

incompatible character encodings: UTF-8 and ASCII-8BIT /home/git/.rvm/gems/ruby-1.9.3-p194/bundler/gems/geokit-e712f0a7b21a/lib/geokit/services/google3.rb:63:in `do_geocode'
```
