### PR TITLE
Quick service fix gets yahoo maps api back to work!

### DIFF
--- a/lib/geokit/services/yahoo.rb
+++ b/lib/geokit/services/yahoo.rb
@@ -20,7 +20,7 @@ module Geokit
       def self.json2GeoLoc(json, address)
         results = MultiJson.load(json)
 
-        if results['ResultSet']['Error'] == 0 && results['ResultSet']['Results'] != nil && results['ResultSet']['Results'].first != nil
+        if results['ResultSet']['Error'].to_i == 0 && results['ResultSet']['Results'] != nil && results['ResultSet']['Results'].first != nil
           geoloc = nil
           results['ResultSet']['Results'].each do |result|
             extracted_geoloc = extract_geoloc(result)


### PR DESCRIPTION
Cast results['ResultSet']['Error'] to an integer because yahoo will return the string '0', accidentally logging an error.
