### PR TITLE
Clean up links in Readme and Gemspec

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -19,7 +19,6 @@ The Geokit gem provides:
 
 Combine this gem with the [geokit-rails plugin](http://github.com/geokit/geokit-rails) to get location-based finders for your Rails app.
 
-* Geokit main site [http://rubygeokit.org/](http://rubygeokit.org).
 * Repository at Github: [http://github.com/geokit/geokit](http://github.com/geokit/geokit).
 * RDoc pages: [http://rdoc.info/github/geokit/geokit/master/frames](http://rdoc.info/github/geokit/geokit/master/frames)
 * Follow the Google Group for updates and discussion on Geokit: [http://groups.google.com/group/geokit](http://groups.google.com/group/geokit)

--- a/geokit.gemspec
+++ b/geokit.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.email         = ["michael+geokit@noack.com.au"]
   spec.description   = %q{Geokit provides geocoding and distance calculation in an easy-to-use API}
   spec.summary       = %q{Geokit: encoding and distance calculation gem}
-  spec.homepage      = "http://geokit.org"
+  spec.homepage      = "http://github.com/geokit/geokit"
   spec.license       = "MIT"
 
   spec.has_rdoc = true


### PR DESCRIPTION
Hi!

A number of links from imajes/geokit were redirecting to geokit/geokit so I pointed them directly to geokit/geokit.  A couple of sites no longer existed, so I removed links to them.

As a side note, http://geokit.rubyforge.org/ has some old, broken links, and an old version of them gem.  I'm not sure how much control you have over that, but given how high it ranks on Google compared to the github repo or rubygems.org, it would be good to either remove it or update it.
