### PR TITLE
Drop ruby 1.8 support (see #104)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: ruby
 rvm:
-  - ree
-  - 1.8.7
-  - 1.9.2
   - 1.9.3
   - 2.0.0
 script: "bundle exec rake coverage"

--- a/geokit.gemspec
+++ b/geokit.gemspec
@@ -22,6 +22,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = '>= 1.9.3'
+
   spec.add_dependency "multi_json", ">= 1.3.2"
   spec.add_development_dependency "bundler", "> 1.0"
   spec.add_development_dependency 'simplecov'


### PR DESCRIPTION
- Specify a minimum ruby version of 1.9.3 in the gemspec. This will prevent 1.8 users from updating.
- Remove REE, 1.8.7, and 1.9.2 from travis.
