### PR TITLE
Return countries with two alpha characters in maxmind geocoder

### DIFF
--- a/lib/geokit/geocoders/maxmind.rb
+++ b/lib/geokit/geocoders/maxmind.rb
@@ -26,7 +26,7 @@ module Geokit
           :city     => res.city_name,
           :state    => res.region_name,
           :zip      => res.postal_code,
-          :country_code => res.country_code3
+          :country_code => res.country_code2
         )
 
         loc.success = ( res.longitude.kind_of?(Numeric) && res.latitude.kind_of?(Numeric) )

--- a/test/test_maxmind_geocoder.rb
+++ b/test/test_maxmind_geocoder.rb
@@ -17,10 +17,11 @@ class MaxmindGeocoderTest < BaseGeocoderTest #:nodoc: all
     city.stubs(:city_name).returns('Adelaide')
     city.stubs(:region_name).returns('Australia')
     city.stubs(:postal_code).returns('')
-    city.stubs(:country_code3).returns('AUS')
+    city.stubs(:country_code2).returns('AU')
 
     res = Geokit::Geocoders::MaxmindGeocoder.geocode(@ip)
     assert_equal 'Adelaide', res.city
+    assert_equal 'AU', res.country_code
     assert_equal true, res.success
     assert res.city
   end
@@ -35,10 +36,11 @@ class MaxmindGeocoderTest < BaseGeocoderTest #:nodoc: all
     city.stubs(:city_name).returns('Canelones')
     city.stubs(:region_name).returns('')
     city.stubs(:postal_code).returns('')
-    city.stubs(:country_code3).returns('URY')
+    city.stubs(:country_code2).returns('UR')
 
     res = Geokit::Geocoders::MaxmindGeocoder.geocode(@ip)
     assert_equal 'Canelones', res.city
+    assert_equal 'UR', res.country_code
     assert_equal true, res.success
     assert res.city
   end


### PR DESCRIPTION
Return countries as two alpha characters on maxmind geocoder as the same as other geocoders:

This is the current behaviour:

```
irb(main):001:0> Geokit::Geocoders::IpGeocoder.geocode('8.8.8.8').country_code
=> "US"
irb(main):002:0> Geokit::Geocoders::RipeGeocoder.geocode('8.8.8.8').country_code
=> "US"
irb(main):003:0> Geokit::Geocoders::MaxmindGeocoder.geocode('8.8.8.8').country_code
=> "USA"
``
```
