### PR TITLE
Prevent Ruby 1.8 error with rescue clause

### DIFF
--- a/lib/geokit/mappable.rb
+++ b/lib/geokit/mappable.rb
@@ -61,11 +61,11 @@ module Geokit
       end
 
       def math_error_classes
-        error_classes = [Errno::EDOM]
-
-        # Ruby 1.9 raises {Math::DomainError}, but it is not defined in Ruby
-        # 1.8. Backwards-compatibly rescue both errors.
-        error_classes << Math::DomainError if defined?(Math::DomainError)
+        [Errno::EDOM].tap do |error_classes|
+          # Ruby 1.9 raises {Math::DomainError}, but it is not defined in Ruby
+          # 1.8. Backwards-compatibly rescue both errors.
+          error_classes << Math::DomainError if defined?(Math::DomainError)
+        end
       end
 
       # Returns heading in degrees (0 is north, 90 is east, 180 is south, etc)


### PR DESCRIPTION
In Ruby 1.8, the final line of the math_error_classes method would
return nil if Math::DomainError was not defined. That would cause the
rescue in distance_between_sphere to be effectively `rescue *nil`, which
produces "TypeError: class or module required for rescue clause".
