### PR TITLE
Remove errant debug line in HTTP adapter

### DIFF
--- a/lib/geokit/net_adapter/net_http.rb
+++ b/lib/geokit/net_adapter/net_http.rb
@@ -15,7 +15,6 @@ module Geokit
           http.use_ssl = true
           http.verify_mode = Geokit::Geocoders.ssl_verify_mode
         end
-        http.set_debug_output STDOUT
         http.start { |http| http.request(req) }
       end
 


### PR DESCRIPTION
I accidentally left a line in from debugging SSL connections to one of the geocoders.  
