### PR TITLE
MultiGeocoder accepts a custom provider order

### DIFF
--- a/lib/geokit/multi_geocoder.rb
+++ b/lib/geokit/multi_geocoder.rb
@@ -23,8 +23,7 @@ module Geokit
       # The failover approach is crucial for production-grade apps, but is rarely used.
       # 98% of your geocoding calls will be successful with the first call
       def self.do_geocode(address, *args)
-        geocode_ip = /^(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/.match(address)
-        provider_order = geocode_ip ? Geokit::Geocoders::ip_provider_order : Geokit::Geocoders::provider_order
+        provider_order = provider_order_for(address, args)
 
         provider_order.each do |provider|
           klass = geocoder(provider)
@@ -58,6 +57,18 @@ module Geokit
 
       def self.geocoder(provider)
         Geokit::Geocoders.const_get "#{Geokit::Inflector::camelize(provider.to_s)}Geocoder"
+      end
+
+      def self.provider_order_for(address, args)
+        if args.last.is_a?(Hash) && args.last.key?(:provider_order)
+          args.last.delete(:provider_order)
+        else
+          if /^(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/.match(address)
+            Geokit::Geocoders::ip_provider_order
+          else
+            Geokit::Geocoders::provider_order
+          end
+        end
       end
     end
   end

--- a/test/test_multi_geocoder.rb
+++ b/test/test_multi_geocoder.rb
@@ -92,4 +92,11 @@ class MultiGeocoderTest < BaseGeocoderTest #:nodoc: all
     assert_equal @failure, Geokit::Geocoders::MultiGeocoder.reverse_geocode("")
     Geokit::Geocoders.provider_order = t1 # reset to orig values
   end
+
+  def test_custom_provider_order
+    Geokit::Geocoders::YahooGeocoder.expects(:geocode).with(@address, {}).returns(@success)
+    Geokit::Geocoders::GoogleGeocoder.expects(:geocode).never
+    Geokit::Geocoders::UsGeocoder.expects(:geocode).never
+    assert_equal @success, Geokit::Geocoders::MultiGeocoder.geocode(@address, :provider_order => [:yahoo, :google, :us])
+  end
 end


### PR DESCRIPTION
This allows `MultiGeocoder.geocode` to follow a provider order different from the one set globally via `Geokit::Geocoders.provider_order`.

Example:

``` ruby
Geokit::Geocoders::MultiGeocoder.geocode "Address, City",
  :provider_order => [:google, :yahoo]
```
