### PR TITLE
Trust that Google is sorting the results per their documentation

### DIFF
--- a/lib/geokit/services/google3.rb
+++ b/lib/geokit/services/google3.rb
@@ -101,11 +101,10 @@ module Geokit
           raise Geokit::Geocoders::GeocodeError
         end
 
-        unsorted = results['results'].map do |addr|
+        all = results['results'].map do |addr|
           single_json_to_geoloc(addr)
         end
 
-        all = unsorted.sort_by(&:accuracy).reverse
         encoded = all.first
         encoded.all = all
         encoded


### PR DESCRIPTION
Per [Google's Geocoder documentation on reverse geocoding](https://developers.google.com/maps/documentation/geocoding/#reverse-example):

> Generally, addresses are returned from most specific to least specific; the more exact address is the most prominent result

We should trust the Google's results are ordered, as the Ruby sort & reverse implementation is skewing the relevancy of results.
