### PR TITLE
Get.new(url) or Get.new(uri)

### DIFF
--- a/lib/geokit/net_adapter/net_http.rb
+++ b/lib/geokit/net_adapter/net_http.rb
@@ -3,7 +3,7 @@ module Geokit
     class NetHttp
       def self.do_get(url)
         uri = URI.parse(url)
-        req = Net::HTTP::Get.new(url)
+        req = Net::HTTP::Get.new(uri)
         req.basic_auth(uri.user, uri.password) if uri.userinfo
         net_http_args = [uri.host, uri.port]
         if (proxy_uri_string = Geokit::Geocoders::proxy)


### PR DESCRIPTION
In some envs creating a Get with url the response is not 200, using uri
it doesn’t happen.