### PR TITLE
Fix Geocoder to use updated URL and throws an error unless key is specif...

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -152,11 +152,20 @@ If you're using this gem by itself, here are the configuration options:
     # and http://geocoder.ca/?register=1
     Geokit::Geocoders::CaGeocoder.key = 'KEY'
 
+    # This is your username key for geonames.
+    # To use this service either free or premium, you must register a key.
+    # See http://www.geonames.org
+    Geokit::Geocoders::GeonamesGeocoder.key = 'KEY'
+
     # Most other geocoders need either no setup or a key
     Geokit::Geocoders::BingGeocoder.key = ''
-    Geokit::Geocoders::GeonamesGeocoder.key = ''
     Geokit::Geocoders::MapQuestGeocoder.key = ''
     Geokit::Geocoders::YandexGeocoder.key = ''
+
+    # Geonames has a free service and a premium service, each using a different URL
+    # GeonamesGeocoder.premium = true will use http://ws.geonames.net (premium)
+    # GeonamesGeocoder.premium = false will use http://api.geonames.org (free)
+    Geokit::Geocoders::GeonamesGeocoder.premium = false
 
     # require "external_geocoder.rb"
     # Please see the section "writing your own geocoders" for more information.

--- a/fixtures/vcr_cassettes/geonames_geocode.yml
+++ b/fixtures/vcr_cassettes/geonames_geocode.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ws.geonames.org/postalCodeSearch?maxRows=10&placename=Adelaide
+    uri: http://api.geonames.org/postalCodeSearch?maxRows=10&placename=Adelaide&username=demo
     body:
       encoding: US-ASCII
       string: ''

--- a/fixtures/vcr_cassettes/geonames_geocode_premium.yml
+++ b/fixtures/vcr_cassettes/geonames_geocode_premium.yml
@@ -1,0 +1,42 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://ws.geonames.net/postalCodeSearch?maxRows=10&placename=Adelaide&username=demo
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 20 Jun 2014 02:41:39 GMT
+      Server:
+      - Apache/2.2.17 (Linux/SUSE)
+      Cache-Control:
+      - no-cache
+      Access-Control-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - text/xml;charset=UTF-8
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+        <geonames>
+        <status message="Please provide a valid username for the GeoNames Premium Web Service or use the free api.geonames.org server. Thank you for your understanding." value="10"/>
+        </geonames>
+    http_version: 
+  recorded_at: Fri, 20 Jun 2014 02:41:29 GMT
+recorded_with: VCR 2.9.2

--- a/test/test_geonames_geocoder.rb
+++ b/test/test_geonames_geocoder.rb
@@ -4,20 +4,41 @@ class GeonamesGeocoderTest < BaseGeocoderTest #:nodoc: all
   def setup
     super
     @city = 'Adelaide'
+    Geokit::Geocoders::GeonamesGeocoder.key = 'demo'
   end
 
   def assert_url(expected_url)
     assert_equal expected_url, TestHelper.get_last_url.gsub(/&oauth_[a-z_]+=[a-zA-Z0-9\-. %]+/, '').gsub('%20', '+')
   end
 
+  def test_geonames_missing_key
+    Geokit::Geocoders::GeonamesGeocoder.key = nil
+    exception = assert_raise(Geokit::Geocoders::GeocodeError) do
+      Geokit::Geocoders::GeonamesGeocoder.geocode(@city)
+    end
+    assert_equal('Geonames requires a key to use their service.', exception.message)
+  end
+
   def test_geonames_geocode
     VCR.use_cassette('geonames_geocode') do
-    url = "http://ws.geonames.org/postalCodeSearch?placename=#{@city}&maxRows=10"
-    res = Geokit::Geocoders::GeonamesGeocoder.geocode(@city)
-    assert_url url
-    assert_equal res.country_code, 'AU'
-    assert_equal res.state, 'South Australia'
-    assert_equal res.city, 'Adelaide'
+      url = "http://api.geonames.org/postalCodeSearch?placename=#{@city}&maxRows=10&username=demo"
+      res = Geokit::Geocoders::GeonamesGeocoder.geocode(@city)
+      assert_url url
+      assert_equal res.country_code, 'AU'
+      assert_equal res.state, 'South Australia'
+      assert_equal res.city, 'Adelaide'
     end
   end
+
+  def test_geonames_geocode_premium
+    # note this test will not actually return results because a valid premium 
+    # username is required so we are just testing if the url is correct
+    Geokit::Geocoders::GeonamesGeocoder.premium = true
+    VCR.use_cassette('geonames_geocode_premium') do
+      url = "http://ws.geonames.net/postalCodeSearch?placename=#{@city}&maxRows=10&username=demo"
+      res = Geokit::Geocoders::GeonamesGeocoder.geocode(@city)
+      assert_url url
+    end
+  end
+
 end


### PR DESCRIPTION
...ied as it is now required. 

 This update uses the new URL of api.geonames.org as ws.geonames.org is being depricated. Also the previous version was using ws.geonames.net (instead of .org). 

 Since Geonames now requires the use of a registered key to use, I changed it to throw an error if a key is not set.
