### PR TITLE
Allow users to use latitude and longitude to access lat and lng for GeoK...

### DIFF
--- a/lib/geokit/lat_lng.rb
+++ b/lib/geokit/lat_lng.rb
@@ -4,6 +4,15 @@ module Geokit
 
     attr_accessor :lat, :lng
 
+    # Provide users with the ability to use :latitude and :longitude
+    # to access the lat/lng instance variables.
+    # Alias the attr_accessor :lat to :latitude
+    alias_method :latitude, :lat
+    alias_method :latitude=, :lat=
+    # Alias the attr_accessor :lng to :longitude
+    alias_method :longitude, :lng
+    alias_method :longitude=, :lng=
+
     # Accepts latitude and longitude or instantiates an empty instance
     # if lat and lng are not provided. Converted to floats if provided
     def initialize(lat=nil, lng=nil)

--- a/test/test_latlng.rb
+++ b/test/test_latlng.rb
@@ -27,6 +27,22 @@ class LatLngTest < Test::Unit::TestCase #:nodoc: all
     location
   end
 
+  def test_existance_of_latitude_alias
+    assert_respond_to(@loc_a, :latitude)
+  end
+
+  def test_existance_of_longitude_alias
+    assert_respond_to(@loc_a, :longitude)
+  end
+
+  def test_that_lat_and_latitude_are_same_object
+    assert_same(@loc_a.lat, @loc_a.latitude)
+  end
+
+  def test_that_lng_and_longitude_are_same_object
+    assert_same(@loc_a.lng, @loc_a.longitude)
+  end
+
   def test_distance_between_same_using_defaults
     assert_equal 0, Geokit::LatLng.distance_between(@loc_a, @loc_a)
     assert_equal 0, @loc_a.distance_to(@loc_a)


### PR DESCRIPTION
This pull request provides the ability to call latitude and longitude on Geokit::LatLng objects.  Many existing projects use the more verbose names of latitude and longitude.  For projects that do this you are utilizing two different names for looking up the same objects when using Geokit.  This allows the user the ability to choose whichever naming convention matches their existing code without impacting current users of Geokit by aliasing Geokit::LatLng attr_accessors `:lat` and `:lng` to `:latitude` and `:longitude`. 

I'll be more than happy to change the test methods to test equivalency instead of object reference if you would prefer as well.
