### PR TITLE
Implementation and tests for generating a polygons centroid

### DIFF
--- a/lib/geokit/polygon.rb
+++ b/lib/geokit/polygon.rb
@@ -36,5 +36,31 @@ module Geokit
 
       oddNodes
     end # contains?
+
+    def centroid
+      centroid_lat = 0.0
+      centroid_lng = 0.0
+      signed_area = 0.0
+
+      # Iterate over each element in the list but the last item as it's
+      # calculated by the i+1 logic
+      @points[0...-1].each_index { |i|
+        x0 = @points[i].lat
+        y0 = @points[i].lng
+        x1 = @points[i+1].lat
+        y1 = @points[i+1].lng
+        a = x0*y1 - x1*y0
+        signed_area += a
+        centroid_lat += (x0 + x1)*a
+        centroid_lng += (y0 + y1)*a
+      }
+
+      signed_area *= 0.5
+      centroid_lat /= (6.0*signed_area)
+      centroid_lng /= (6.0*signed_area)
+      
+      Geokit::LatLng.new(centroid_lat, centroid_lng)
+    end # end centroid
+
   end # class Polygon
 end

--- a/test/test_polygon.rb
+++ b/test/test_polygon.rb
@@ -15,6 +15,8 @@ class PolygonTest < Test::Unit::TestCase #:nodoc: all
     @points = [@p1, @p2, @p3, @p4, @p5]
     @polygon = Geokit::Polygon.new(@points)
 
+    @polygon_centroid = Geokit::LatLng.new(45.27463866133501, -93.41400121829719)
+
     @point_inside = Geokit::LatLng.new(45.27428243796789, -93.41648483416066)
     @point_outside = Geokit::LatLng.new(45.45411010558687, -93.78151703160256)
 
@@ -34,6 +36,8 @@ class PolygonTest < Test::Unit::TestCase #:nodoc: all
     @complex_points = [@c1, @c2, @c3, @c4, @c5, @c6, @c7, @c8, @c9, @c10, @c11]
     @complex_polygon = Geokit::Polygon.new(@complex_points)
 
+    @complex_polygon_centroid = Geokit::LatLng.new(45.43622702936517, -93.5352210389731)
+
     #Test three points that should be "inside" this complex shape
     @complex_inside_one = Geokit::LatLng.new(45.52438983143154, -93.59818268101662)
     @complex_inside_two = Geokit::LatLng.new(45.50321887154943, -93.37845611851662)
@@ -52,6 +56,8 @@ class PolygonTest < Test::Unit::TestCase #:nodoc: all
 
     @open_points = [@op1, @op2, @op3, @op4]
     @open_polygon = Geokit::Polygon.new(@open_points)
+
+    @open_polygon_centroid = Geokit::LatLng.new(44.95912726688109, -92.7068888186181)
 
   end
 
@@ -95,7 +101,18 @@ class PolygonTest < Test::Unit::TestCase #:nodoc: all
 
     assert @open_polygon.points[0].lng == @open_polygon.points[-1].lng
     assert @open_polygon.points[0].lat == @open_polygon.points[-1].lat
+  end
 
+  def test_centroid_for_simple_poly
+    assert_equal(@polygon.centroid, @polygon_centroid)
+  end
+
+  def test_centroid_for_complex_poly
+    assert_equal(@complex_polygon.centroid, @complex_polygon_centroid)
+  end
+
+  def test_centroid_for_open_poly
+    assert_equal(@open_polygon.centroid, @open_polygon_centroid)
   end
 
 end


### PR DESCRIPTION
Logic to generate the centroid of a polygon.
http://en.wikipedia.org/wiki/Centroid

Can be used as a ruff center of a polygon if necessary but is logically different. 

Here is the test data with the proper centroid for demonstration.  The centroid is the last point in the list of points so you can easily remove and add it back in to see where it is.

Simple Polygon
http://www.darrinward.com/lat-long/?id=224260

Complex Polygon
http://www.darrinward.com/lat-long/?id=224264

Open Polygon
http://www.darrinward.com/lat-long/?id=224259

Please let me know if you'd like me to create a separate test file instead of renaming the polygon_contains test and using it for both pieces of logic. 
