### PR TITLE
Update centroid logic to cacluate once and update code to match stylegui...

### DIFF
--- a/lib/geokit/polygon.rb
+++ b/lib/geokit/polygon.rb
@@ -37,30 +37,38 @@ module Geokit
       oddNodes
     end # contains?
 
+    # A polygon is static and can not be updated with new points, as a result
+    # calculate the centroid once and store it when requested.
     def centroid
+      @centroid ||= calculate_centroid
+    end # end centroid
+
+    private
+
+    def calculate_centroid
       centroid_lat = 0.0
       centroid_lng = 0.0
       signed_area = 0.0
 
       # Iterate over each element in the list but the last item as it's
       # calculated by the i+1 logic
-      @points[0...-1].each_index { |i|
+      @points[0...-1].each_index do |i|
         x0 = @points[i].lat
         y0 = @points[i].lng
-        x1 = @points[i+1].lat
-        y1 = @points[i+1].lng
-        a = x0*y1 - x1*y0
+        x1 = @points[i + 1].lat
+        y1 = @points[i + 1].lng
+        a = (x0 * y1) - (x1 * y0)
         signed_area += a
-        centroid_lat += (x0 + x1)*a
-        centroid_lng += (y0 + y1)*a
-      }
+        centroid_lat += (x0 + x1) * a
+        centroid_lng += (y0 + y1) * a
+      end
 
       signed_area *= 0.5
-      centroid_lat /= (6.0*signed_area)
-      centroid_lng /= (6.0*signed_area)
-      
+      centroid_lat /= (6.0 * signed_area)
+      centroid_lng /= (6.0 * signed_area)
+
       Geokit::LatLng.new(centroid_lat, centroid_lng)
-    end # end centroid
+    end # end calculate_centroid
 
   end # class Polygon
 end

--- a/test/test_polygon.rb
+++ b/test/test_polygon.rb
@@ -15,8 +15,6 @@ class PolygonTest < Test::Unit::TestCase #:nodoc: all
     @points = [@p1, @p2, @p3, @p4, @p5]
     @polygon = Geokit::Polygon.new(@points)
 
-    @polygon_centroid = Geokit::LatLng.new(45.27463866133501, -93.41400121829719)
-
     @point_inside = Geokit::LatLng.new(45.27428243796789, -93.41648483416066)
     @point_outside = Geokit::LatLng.new(45.45411010558687, -93.78151703160256)
 
@@ -36,8 +34,6 @@ class PolygonTest < Test::Unit::TestCase #:nodoc: all
     @complex_points = [@c1, @c2, @c3, @c4, @c5, @c6, @c7, @c8, @c9, @c10, @c11]
     @complex_polygon = Geokit::Polygon.new(@complex_points)
 
-    @complex_polygon_centroid = Geokit::LatLng.new(45.43622702936517, -93.5352210389731)
-
     #Test three points that should be "inside" this complex shape
     @complex_inside_one = Geokit::LatLng.new(45.52438983143154, -93.59818268101662)
     @complex_inside_two = Geokit::LatLng.new(45.50321887154943, -93.37845611851662)
@@ -56,9 +52,6 @@ class PolygonTest < Test::Unit::TestCase #:nodoc: all
 
     @open_points = [@op1, @op2, @op3, @op4]
     @open_polygon = Geokit::Polygon.new(@open_points)
-
-    @open_polygon_centroid = Geokit::LatLng.new(44.95912726688109, -92.7068888186181)
-
   end
 
   def test_point_inside_poly
@@ -104,14 +97,17 @@ class PolygonTest < Test::Unit::TestCase #:nodoc: all
   end
 
   def test_centroid_for_simple_poly
+    @polygon_centroid = Geokit::LatLng.new(45.27463866133501, -93.41400121829719)
     assert_equal(@polygon.centroid, @polygon_centroid)
   end
 
   def test_centroid_for_complex_poly
+    @complex_polygon_centroid = Geokit::LatLng.new(45.43622702936517, -93.5352210389731)
     assert_equal(@complex_polygon.centroid, @complex_polygon_centroid)
   end
 
   def test_centroid_for_open_poly
+    @open_polygon_centroid = Geokit::LatLng.new(44.95912726688109, -92.7068888186181)
     assert_equal(@open_polygon.centroid, @open_polygon_centroid)
   end
 


### PR DESCRIPTION
Updated test as per comments on initial PR (https://github.com/geokit/geokit/pull/147) by including localized test variables within the test method.

Cached centroid calculation as right now polygons are static and can not have new points added after creation.  I did this on demand as opposed to object initialization, input welcome on maintainer preferences.

Did not resolve hound line length comments but will be happy to do so if requested.  Updated code to reflect style guide comments aside from that. 
