### PR TITLE
Workaround for Google sublocality bug

### DIFF
--- a/fixtures/vcr_cassettes/google_sublocality.yml
+++ b/fixtures/vcr_cassettes/google_sublocality.yml
@@ -1,0 +1,126 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://maps.google.com/maps/api/geocode/json?address=682%20prospect%20place%20Brooklyn%20ny%2011216&sensor=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Sun, 26 Jan 2014 05:46:39 GMT
+      Expires:
+      - Mon, 27 Jan 2014 05:46:39 GMT
+      Cache-Control:
+      - public, max-age=86400
+      Vary:
+      - Accept-Language
+      Access-Control-Allow-Origin:
+      - '*'
+      Server:
+      - mafe
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+      Alternate-Protocol:
+      - 443:quic
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+       {
+         "results" : [
+            {
+               "address_components" : [
+                  {
+                     "long_name" : "682",
+                     "short_name" : "682",
+                     "types" : [ "street_number" ]
+                  },
+                  {
+                     "long_name" : "Prospect Place",
+                     "short_name" : "Prospect Pl",
+                     "types" : [ "route" ]
+                  },
+                  {
+                     "long_name" : "Crown Heights",
+                     "short_name" : "Crown Heights",
+                     "types" : [ "neighborhood", "political" ]
+                  },
+                  {
+                     "long_name" : "Brooklyn",
+                     "short_name" : "Brooklyn",
+                     "types" : [ "sublocality_level_1", "sublocality", "political" ]
+                  },
+                  {
+                     "long_name" : "Kings County",
+                     "short_name" : "Kings County",
+                     "types" : [ "administrative_area_level_2", "political" ]
+                  },
+                  {
+                     "long_name" : "New York",
+                     "short_name" : "NY",
+                     "types" : [ "administrative_area_level_1", "political" ]
+                  },
+                  {
+                     "long_name" : "United States",
+                     "short_name" : "US",
+                     "types" : [ "country", "political" ]
+                  },
+                  {
+                     "long_name" : "11216",
+                     "short_name" : "11216",
+                     "types" : [ "postal_code" ]
+                  }
+               ],
+               "formatted_address" : "682 Prospect Place, Brooklyn, NY 11216, USA",
+               "geometry" : {
+                  "bounds" : {
+                     "northeast" : {
+                        "lat" : 40.6745947,
+                        "lng" : -73.9541534
+                     },
+                     "southwest" : {
+                        "lat" : 40.6745812,
+                        "lng" : -73.95415819999999
+                     }
+                  },
+                  "location" : {
+                     "lat" : 40.6745812,
+                     "lng" : -73.95415819999999
+                  },
+                  "location_type" : "RANGE_INTERPOLATED",
+                  "viewport" : {
+                     "northeast" : {
+                        "lat" : 40.6759369302915,
+                        "lng" : -73.95280681970848
+                     },
+                     "southwest" : {
+                        "lat" : 40.6732389697085,
+                        "lng" : -73.95550478029149
+                     }
+                  }
+               },
+               "types" : [ "street_address" ]
+            }
+         ],
+         "status" : "OK"
+         }
+    http_version:
+  recorded_at: Sun, 26 Jan 2014 05:46:39 GMT
+recorded_with: VCR 2.8.0

--- a/lib/geokit/geocoders/google.rb
+++ b/lib/geokit/geocoders/google.rb
@@ -181,6 +181,8 @@ module Geokit
             loc.district = comp['long_name']
           when types.include?('neighborhood')
             loc.neighborhood = comp['short_name']
+          when types.include?("sublocality")
+            loc.city = comp['long_name'] if loc.city.nil?
           end
         end
       end

--- a/test/test_google_geocoder.rb
+++ b/test/test_google_geocoder.rb
@@ -103,6 +103,22 @@ class GoogleGeocoderTest < BaseGeocoderTest #:nodoc: all
      end
    end
 
+   def test_google_sublocality
+     @address = "682 prospect place Brooklyn ny 11216"
+     VCR.use_cassette('google_sublocality') do
+     url = "https://maps.google.com/maps/api/geocode/json?sensor=false&address=#{Geokit::Inflector::url_escape(@address)}"
+     TestHelper.expects(:last_url).with(url)
+     res=Geokit::Geocoders::GoogleGeocoder.do_geocode(@address)
+     assert_equal "682 Prospect Place", res.street_address
+     assert_equal "NY", res.state
+     assert_equal "Brooklyn", res.city
+     assert_equal "40.6745812,-73.9541582", res.ll
+     assert res.is_us?
+     assert_equal "682 Prospect Place, Brooklyn, NY 11216, USA", res.full_address
+     assert_equal "google", res.provider
+     end
+   end
+
    def test_google_city_accuracy
      VCR.use_cassette('google_city') do
      url = "https://maps.google.com/maps/api/geocode/json?sensor=false&address=#{Geokit::Inflector::url_escape(@address)}"


### PR DESCRIPTION
Handles https://code.google.com/p/gmaps-api-issues/issues/detail?id=3320
Google's Geocoder will sometimes return a blank locality and a populated sublocality.
This is common for NY city addresses.

This fix will use sublocality for city if locality is blank, and allow locality to overwrite city if the return has both.
