### PR TITLE
Add Opencage Geocoder implementation

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -46,12 +46,14 @@ Combine this gem with the [geokit-rails](http://github.com/geokit/geokit-rails) 
 * MapQuest
 * Geocod.io
 * Mapbox - requires an access token
+* [OpenCage](http://geocoder.opencagedata.com) - requires an API key
 
 ### address geocoders that also provide reverse geocoding
 * Google - Supports multiple results and bounding box/country code biasing.  Also supports Maps API for Business keys; see the configuration section below.
 * FCC
-* Open Street Map
+* OpenStreetMap
 * Mapbox
+* OpenCage
 
 ### IP address geocoders
 * IP - geocodes an IP address using hostip.info's web service.
@@ -67,6 +69,7 @@ Combine this gem with the [geokit-rails](http://github.com/geokit/geokit-rails) 
 * FCC
 * MapQuest
 * Mapbox
+* OpenCage
 
 Options to control the use of HTTPS are described below in the Configuration section.
 
@@ -165,6 +168,7 @@ If you're using this gem by itself, here are the configuration options:
     Geokit::Geocoders::MapQuestGeocoder.key = ''
     Geokit::Geocoders::YandexGeocoder.key = ''
     Geokit::Geocoders::MapboxGeocoder.key = 'ACCESS_TOKEN'
+    Geokit::Geocoders::OpencageGeocoder.key = 'some_api_key'
 
     # Geonames has a free service and a premium service, each using a different URL
     # GeonamesGeocoder.premium = true will use http://ws.geonames.net (premium)

--- a/fixtures/vcr_cassettes/opencage_city.yml
+++ b/fixtures/vcr_cassettes/opencage_city.yml
@@ -1,0 +1,51 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.opencagedata.com/geocode/v1/json?key=someopencageapikey&no_annotations=1&query=San%20Francisco,%20CA
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 03 Sep 2014 14:08:51 GMT
+      Server:
+      - Apache/2.4.7 (Ubuntu)
+      X-Ratelimit-Reset:
+      - '1409788800'
+      X-Ratelimit-Remaining:
+      - '2466'
+      X-Ratelimit-Limit:
+      - '2500'
+      Access-Control-Allow-Origin:
+      - '*'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '{"licenses":[{"name":"CC-BY-SA","url":"http://creativecommons.org/licenses/by-sa/3.0/"},{"name":"ODbL","url":"http://opendatacommons.org/licenses/odbl/summary/"}],"rate":{"limit":2500,"remaining":2466,"reset":1409788800},"results":[{"bounds":{"northeast":{"lat":37.9298443,"lng":-122.2817799},"southwest":{"lat":37.63983,"lng":-123.1738249}},"components":{"city":"San
+        Francisco","country":"United States of America","country_code":"US","county":"San
+        Francisco City and County","state":"California"},"confidence":1,"formatted":"San
+        Francisco, San Francisco City and County, California, United States of America","geometry":{"lat":37.7792768,"lng":-122.4192704}},{"bounds":{"northeast":{"lat":37.9298443,"lng":-122.2817799},"southwest":{"lat":37.63983,"lng":-123.1738249}},"components":{"country":"United
+        States of America","country_code":"US","county":"San Francisco City and County","state":"California"},"confidence":1,"formatted":"San
+        Francisco City and County, California, United States of America","geometry":{"lat":37.7647993,"lng":-122.4629897}}],"status":{"code":200,"message":"OK"},"thanks":"For
+        using an OpenCage Data API","timestamp":{"created_http":"Wed, 03 Sep 2014
+        14:08:51 GMT","created_unix":1409753331},"total_results":2,"we_are_hiring":"http://lokku.com/#jobs"}'
+    http_version: 
+  recorded_at: Wed, 03 Sep 2014 14:03:54 GMT
+recorded_with: VCR 2.9.2

--- a/fixtures/vcr_cassettes/opencage_full.yml
+++ b/fixtures/vcr_cassettes/opencage_full.yml
@@ -1,0 +1,65 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.opencagedata.com/geocode/v1/json?key=someopencageapikey&no_annotations=1&query=100%20Spear%20St,%20San%20Francisco,%20CA,%2094105,%20US
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 03 Sep 2014 13:51:27 GMT
+      Server:
+      - Apache/2.4.7 (Ubuntu)
+      Access-Control-Allow-Origin:
+      - '*'
+      X-Ratelimit-Remaining:
+      - '2468'
+      X-Ratelimit-Reset:
+      - '1409788800'
+      X-Ratelimit-Limit:
+      - '2500'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '{"licenses":[{"name":"CC-BY-SA","url":"http://creativecommons.org/licenses/by-sa/3.0/"},{"name":"ODbL","url":"http://opendatacommons.org/licenses/odbl/summary/"}],"rate":{"limit":2500,"remaining":2468,"reset":1409788800},"results":[{"bounds":{"northeast":{"lat":37.7923419,"lng":-122.394032},"southwest":{"lat":37.7922419,"lng":-122.394132}},"components":{"bank":"Wells
+        Fargo","city":"San Francisco","country":"United States of America","country_code":"US","county":"San
+        Francisco City and County","house_number":100,"neighbourhood":"Financial District","postcode":94103,"road":"Spear
+        Street","state":"California"},"confidence":10,"formatted":"100, Spear Street,
+        Financial District, San Francisco, San Francisco City and County, 94103, California,
+        United States of America, Wells Fargo","geometry":{"lat":37.7922919,"lng":-122.394082}},{"bounds":{"northeast":{"lat":37.7923695,"lng":-122.3937501},"southwest":{"lat":37.7919565,"lng":-122.3942877}},"components":{"city":"San
+        Francisco","country":"United States of America","country_code":"US","county":"San
+        Francisco City and County","house_number":100,"neighbourhood":"Financial District","postcode":94103,"road":"Spear
+        Street","state":"California"},"confidence":10,"formatted":"100, Spear Street,
+        Financial District, San Francisco, San Francisco City and County, 94103, California,
+        United States of America","geometry":{"lat":37.79215775,"lng":-122.393995576645}},{"bounds":{"northeast":{"lat":37.7923685,"lng":-122.3939964},"southwest":{"lat":37.7922685,"lng":-122.3940964}},"components":{"atm":"Wells
+        Fargo","city":"San Francisco","country":"United States of America","country_code":"US","county":"San
+        Francisco City and County","house_number":100,"neighbourhood":"Financial District","postcode":94103,"road":"Spear
+        Street","state":"California"},"confidence":10,"formatted":"100, Spear Street,
+        Financial District, San Francisco, San Francisco City and County, 94103, California,
+        United States of America, Wells Fargo","geometry":{"lat":37.7923185,"lng":-122.3940464}},{"components":{"country_name":"United
+        States","locality":"San Francisco","region":"CA","street_name":"Spear St","street_number":100},"confidence":0,"formatted":"San
+        Francisco, CA, United States, Spear St, 100","geometry":{"lat":37.792536,"lng":-122.39406}},{"bounds":{"northeast":{"lat":37.796628,"lng":-122.385181},"southwest":{"lat":37.784205,"lng":-122.403431}},"components":{"country":"United
+        States","county":"San Francisco County","postal code":94105,"state":"California"},"confidence":8,"formatted":"San
+        Francisco County, California, United States, 94105","geometry":{"lat":37.7864,"lng":-122.3892}}],"status":{"code":200,"message":"OK"},"thanks":"For
+        using an OpenCage Data API","timestamp":{"created_http":"Wed, 03 Sep 2014
+        13:51:27 GMT","created_unix":1409752287},"total_results":5,"we_are_hiring":"http://lokku.com/#jobs"}'
+    http_version: 
+  recorded_at: Wed, 03 Sep 2014 13:46:30 GMT
+recorded_with: VCR 2.9.2

--- a/fixtures/vcr_cassettes/opencage_language_response_es.yml
+++ b/fixtures/vcr_cassettes/opencage_language_response_es.yml
@@ -1,0 +1,66 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.opencagedata.com/geocode/v1/json?key=someopencageapikey&language=es&no_annotations=1&query=London
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 03 Sep 2014 14:32:11 GMT
+      Server:
+      - Apache/2.4.7 (Ubuntu)
+      X-Ratelimit-Limit:
+      - '2500'
+      X-Ratelimit-Remaining:
+      - '2458'
+      X-Ratelimit-Reset:
+      - '1409788800'
+      Access-Control-Allow-Origin:
+      - '*'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '{"licenses":[{"name":"CC-BY-SA","url":"http://creativecommons.org/licenses/by-sa/3.0/"},{"name":"ODbL","url":"http://opendatacommons.org/licenses/odbl/summary/"}],"rate":{"limit":2500,"remaining":2458,"reset":1409788800},"results":[{"bounds":{"northeast":{"lat":51.6918741,"lng":0.3340155},"southwest":{"lat":51.2867602,"lng":-0.510375}},"components":{"city":"Londres","country":"Reino
+        Unido","country_code":"gb","county":"Londres","state":"Inglaterra","state_district":"Greater
+        London"},"confidence":1,"formatted":"Londres, Reino Unido","geometry":{"lat":51.5073219,"lng":-0.1276474}},{"bounds":{"northeast":{"lat":43.148097,"lng":-81.0860295},"southwest":{"lat":42.828097,"lng":-81.4060295}},"components":{"city":"London","country":"Canad\u00e1","country_code":"CA","state":"Ontario"},"confidence":3,"formatted":"London,
+        Ontario, Canad\u00e1","geometry":{"lat":42.988097,"lng":-81.2460295}},{"bounds":{"northeast":{"lat":37.15226,"lng":-84.0359569},"southwest":{"lat":37.079759,"lng":-84.1262619}},"components":{"city":"London","country":"Estados
+        Unidos de Am\u00e9rica","country_code":"US","county":"Laurel County","state":"Kentucky"},"confidence":7,"formatted":"London,
+        Laurel County, Kentucky, Estados Unidos de Am\u00e9rica","geometry":{"lat":37.1289771,"lng":-84.0832646}},{"bounds":{"northeast":{"lat":43.0677775,"lng":-88.9928881},"southwest":{"lat":43.0277775,"lng":-89.0328881}},"components":{"country":"Estados
+        Unidos de Am\u00e9rica","country_code":"US","county":"Dane County","hamlet":"London","state":"Wisconsin"},"confidence":7,"formatted":"London,
+        Dane County, Wisconsin, Estados Unidos de Am\u00e9rica","geometry":{"lat":43.0477775,"lng":-89.0128881}},{"bounds":{"northeast":{"lat":39.921786,"lng":-83.3899969},"southwest":{"lat":39.85928,"lng":-83.4789229}},"components":{"city":"London","country":"Estados
+        Unidos de Am\u00e9rica","country_code":"US","county":"Madison County","state":"Ohio"},"confidence":7,"formatted":"London,
+        Madison County, Ohio, Estados Unidos de Am\u00e9rica","geometry":{"lat":39.8864493,"lng":-83.448253}},{"bounds":{"northeast":{"lat":36.4884367,"lng":-119.4385394},"southwest":{"lat":36.4734452,"lng":-119.4497698}},"components":{"country":"Estados
+        Unidos de Am\u00e9rica","country_code":"US","county":"Tulare County","state":"California","village":"London"},"confidence":8,"formatted":"London,
+        Tulare County, California, Estados Unidos de Am\u00e9rica","geometry":{"lat":36.4760619,"lng":-119.4431785}},{"bounds":{"northeast":{"lat":35.33814,"lng":-93.1873749},"southwest":{"lat":35.315577,"lng":-93.2726929}},"components":{"city":"London","country":"Estados
+        Unidos de Am\u00e9rica","country_code":"US","county":"Pope County","state":"Arkansas"},"confidence":7,"formatted":"London,
+        Pope County, Arkansas, Estados Unidos de Am\u00e9rica","geometry":{"lat":35.326859,"lng":-93.2405016007635}},{"bounds":{"northeast":{"lat":38.2143567,"lng":-81.3486944},"southwest":{"lat":38.1743567,"lng":-81.3886944}},"components":{"country":"Estados
+        Unidos de Am\u00e9rica","country_code":"US","county":"Kanawha County","hamlet":"London","state":"Virginia
+        Occidental"},"confidence":7,"formatted":"London, Kanawha County, Virginia
+        Occidental, Estados Unidos de Am\u00e9rica","geometry":{"lat":38.1943567,"lng":-81.3686944}},{"bounds":{"northeast":{"lat":41.1636709,"lng":-80.1286716},"southwest":{"lat":41.1236709,"lng":-80.1686716}},"components":{"country":"Estados
+        Unidos de Am\u00e9rica","country_code":"US","county":"Mercer County","hamlet":"London","state":"Pensilvania"},"confidence":7,"formatted":"London,
+        Mercer County, Pensilvania, Estados Unidos de Am\u00e9rica","geometry":{"lat":41.1436709,"lng":-80.1486716}},{"bounds":{"northeast":{"lat":32.2509892,"lng":-94.9243839},"southwest":{"lat":32.2109892,"lng":-94.9643839}},"components":{"country":"Estados
+        Unidos de Am\u00e9rica","country_code":"US","county":"Rusk County","hamlet":"London","state":"Texas"},"confidence":7,"formatted":"London,
+        Rusk County, Texas, Estados Unidos de Am\u00e9rica","geometry":{"lat":32.2309892,"lng":-94.9443839}}],"status":{"code":200,"message":"OK"},"thanks":"For
+        using an OpenCage Data API","timestamp":{"created_http":"Wed, 03 Sep 2014
+        14:32:11 GMT","created_unix":1409754731},"total_results":10,"we_are_hiring":"http://lokku.com/#jobs"}'
+    http_version: 
+  recorded_at: Wed, 03 Sep 2014 14:27:15 GMT
+recorded_with: VCR 2.9.2

--- a/fixtures/vcr_cassettes/opencage_reverse_madrid.yml
+++ b/fixtures/vcr_cassettes/opencage_reverse_madrid.yml
@@ -1,0 +1,51 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.opencagedata.com/geocode/v1/json?key=someopencageapikey&no_annotations=1&query=40.4167413,-3.7032498
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 03 Sep 2014 14:12:59 GMT
+      Server:
+      - Apache/2.4.7 (Ubuntu)
+      Access-Control-Allow-Origin:
+      - '*'
+      X-Ratelimit-Limit:
+      - '2500'
+      X-Ratelimit-Remaining:
+      - '2465'
+      X-Ratelimit-Reset:
+      - '1409788800'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '{"licenses":[{"name":"CC-BY-SA","url":"http://creativecommons.org/licenses/by-sa/3.0/"},{"name":"ODbL","url":"http://opendatacommons.org/licenses/odbl/summary/"}],"rate":{"limit":2500,"remaining":2465,"reset":1409788800},"results":[{"bounds":{"northeast":{"lat":40.4679786,"lng":-3.6835385},"southwest":{"lat":40.4060007,"lng":-3.7033912}},"components":{"address29":"C-3
+        C-4","city":"Madrid","city_district":"Chamber\u00ed","country":"Spain","country_code":"ES","county":"\u00c1rea
+        metropolitana de Madrid y Corredor del Henares","postcode":28036,"road":"Calle
+        de Zurbano","state":"Community of Madrid","suburb":"Chamber\u00ed"},"confidence":7,"formatted":"Calle
+        de Zurbano, Chamber\u00ed, Chamber\u00ed, Madrid, \u00c1rea metropolitana
+        de Madrid y Corredor del Henares, 28036, Community of Madrid, Spain, C-3 C-4","geometry":{"lat":40.4341975,"lng":-3.6930528}}],"status":{"code":200,"message":"OK"},"thanks":"For
+        using an OpenCage Data API","timestamp":{"created_http":"Wed, 03 Sep 2014
+        14:12:59 GMT","created_unix":1409753579},"total_results":1,"we_are_hiring":"http://lokku.com/#jobs"}'
+    http_version: 
+  recorded_at: Wed, 03 Sep 2014 14:08:02 GMT
+recorded_with: VCR 2.9.2

--- a/fixtures/vcr_cassettes/opencage_reverse_prilep.yml
+++ b/fixtures/vcr_cassettes/opencage_reverse_prilep.yml
@@ -1,0 +1,53 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.opencagedata.com/geocode/v1/json?key=someopencageapikey&no_annotations=1&query=41.3527177,21.5497808
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 03 Sep 2014 14:19:24 GMT
+      Server:
+      - Apache/2.4.7 (Ubuntu)
+      X-Ratelimit-Remaining:
+      - '2463'
+      X-Ratelimit-Reset:
+      - '1409788800'
+      X-Ratelimit-Limit:
+      - '2500'
+      Access-Control-Allow-Origin:
+      - '*'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '{"licenses":[{"name":"CC-BY-SA","url":"http://creativecommons.org/licenses/by-sa/3.0/"},{"name":"ODbL","url":"http://opendatacommons.org/licenses/odbl/summary/"}],"rate":{"limit":2500,"remaining":2463,"reset":1409788800},"results":[{"bounds":{"northeast":{"lat":41.3516718,"lng":21.5508583},"southwest":{"lat":41.350177,"lng":21.54897}},"components":{"city":"Prilep","country":"Macedonia","country_code":"MK","county":"Municipality
+        of Prilep","neighbourhood":"\u0416\u0430\u0431\u0438\u043d\u043e \u041c\u0430\u0430\u043b\u043e","road":"\u041f\u0440\u0438\u043b\u0435\u043f\u0441\u043a\u0438
+        \u0411\u0440\u0430\u043d\u0438\u0442\u0435\u043b\u0438","school":"Gimnasium  Mirche
+        Acev","state":"Pelagonia Region","suburb":"\u0411\u043e\u043d\u0447\u0435\u0458\u0446\u0430"},"confidence":10,"formatted":"Gimnasium
+        Mirche Acev, \u041f\u0440\u0438\u043b\u0435\u043f\u0441\u043a\u0438 \u0411\u0440\u0430\u043d\u0438\u0442\u0435\u043b\u0438,
+        \u0411\u043e\u043d\u0447\u0435\u0458\u0446\u0430, \u0416\u0430\u0431\u0438\u043d\u043e
+        \u041c\u0430\u0430\u043b\u043e, Prilep, Municipality of Prilep, Pelagonia
+        Region, Macedonia, Gimnasium Mirche Acev","geometry":{"lat":41.35125945,"lng":21.5498645766622}}],"status":{"code":200,"message":"OK"},"thanks":"For
+        using an OpenCage Data API","timestamp":{"created_http":"Wed, 03 Sep 2014
+        14:19:24 GMT","created_unix":1409753964},"total_results":1,"we_are_hiring":"http://lokku.com/#jobs"}'
+    http_version: 
+  recorded_at: Wed, 03 Sep 2014 14:14:27 GMT
+recorded_with: VCR 2.9.2

--- a/lib/geokit/geocoders/mapbox.rb
+++ b/lib/geokit/geocoders/mapbox.rb
@@ -1,6 +1,6 @@
 module Geokit
   module Geocoders
-    # Mapbox geocoder implementation.  Requires the Geokit::Geocoders::MapboxGeocoder variable to
+    # Mapbox geocoder implementation.  Requires the Geokit::Geocoders::MapboxGeocoder:key variable to
     # contain a Mapbox access token.  Conforms to the interface set by the Geocoder class.
     class MapboxGeocoder < Geocoder
       config :key

--- a/lib/geokit/geocoders/mapquest.rb
+++ b/lib/geokit/geocoders/mapquest.rb
@@ -1,7 +1,7 @@
 module Geokit
   module Geocoders
-    # MapQuest geocoder implementation.  Requires the Geokit::Geocoders::mapquest variable to
-    # contain a MapQuest API key.  Conforms to the interface set by the Geocoder class.
+    # MapQuest geocoder implementation.  Requires the Geokit::Geocoders::MapQuestGeocoder:key
+    # variable to contain a MapQuest API key.  Conforms to the interface set by the Geocoder class.
     class MapQuestGeocoder < Geocoder
       config :key
       self.secure = true

--- a/lib/geokit/geocoders/opencage.rb
+++ b/lib/geokit/geocoders/opencage.rb
@@ -1,0 +1,97 @@
+module Geokit
+  module Geocoders
+    # OpenCage geocoder implementation.  Requires the Geokit::Geocoders::OpencageGeocoder.key
+    # variable to contain an API key.  Conforms to the interface set by the Geocoder class.
+    class OpencageGeocoder < Geocoder
+      config :key
+      self.secure = true
+
+      private
+
+
+      # Template method which does the geocode lookup.
+      def self.do_geocode(address, options = {})
+
+        options_str = generate_param_for_option(:language, options)
+        options_str << generate_param_for_option(:bounds, options)
+        options_str << generate_param_for_option(:min_confidence, options)
+
+
+        address_str = address.is_a?(GeoLoc) ? address.to_geocodeable_s : address
+        url = "#{protocol}://api.opencagedata.com/geocode/v1/json?"
+        url += "key=#{key}#{options_str}&"
+        url += "query=#{Geokit::Inflector::url_escape(address_str)}&"
+        url += "no_annotations=1"
+        process :json, url
+      end
+            # Template method which does the reverse-geocode lookup.
+      def self.do_reverse_geocode(latlng)
+        latlng = LatLng.normalize(latlng)
+        url = "#{protocol}://api.opencagedata.com/geocode/v1/json?"
+        url += "key=#{key}&query=#{latlng.lat},#{latlng.lng}"
+        process :json, url
+      end
+
+      def self.generate_param_for(param, value)
+        "&#{param}=#{Geokit::Inflector::url_escape(value.to_s)}"
+      end
+
+      def self.generate_param_for_option(param, options)
+        options[param] ? "&#{param}=#{Geokit::Inflector::url_escape(options[param])}" : ''
+      end
+
+      def self.generate_bool_param_for_option(param, options)
+        options[param] ? "&#{param}=1" : "&#{param}=0"
+      end
+
+      def self.parse_json(results)
+
+        return GeoLoc.new if results.empty?
+        if results.is_a?(Hash)
+          return GeoLoc.new unless results['status']['message'] == 'OK'
+        end
+
+        loc = nil
+        results['results'].each do |result|
+          extracted_geoloc = extract_geoloc(result)
+          if loc.nil?
+            loc = extracted_geoloc
+          else
+            loc.all.push(extracted_geoloc)
+          end
+        end          
+        loc
+      end
+
+      def self.extract_geoloc(result_json)
+        loc = new_loc
+        loc.lat = result_json['geometry']['lat']
+        loc.lng = result_json['geometry']['lng']
+        set_address_components(result_json['components'], loc)
+        set_precision(result_json, loc)
+        loc.success = true
+        loc
+      end
+
+      def self.set_address_components(address_data, loc)
+        return unless address_data
+        loc.country        = address_data['country']
+        loc.country_code   = address_data['country_code'].upcase if address_data['country_code']
+        loc.state_name     = address_data['state']
+        loc.city           = address_data['city']
+        loc.city           = address_data['county'] if loc.city.nil? && address_data['county']
+        loc.zip            = address_data['postcode']
+        loc.district       = address_data['city_district']
+        loc.district       = address_data['state_district'] if loc.district.nil? && address_data['state_district']
+        loc.street_address = "#{address_data['road']} #{address_data['house_number']}".strip if address_data['road']
+        loc.street_name    = address_data['road']
+        loc.street_number  = address_data['house_number']
+      end
+
+      def self.set_precision(result_json, loc)
+        # a value between 1 (worse) and 10 (best). 0 means unknown
+        loc.precision = result_json['confidence']
+      end
+    end
+  end
+end

--- a/test/test_opencage_geocoder.rb
+++ b/test/test_opencage_geocoder.rb
@@ -1,0 +1,124 @@
+# encoding: utf-8
+require File.join(File.dirname(__FILE__), 'helper')
+
+class OpencageGeocoderTest < BaseGeocoderTest #:nodoc: all
+
+  def setup
+    super
+    @opencage_full_hash = {:street_address=>"100 Spear St", :city=>"San Francisco", :state=>"CA", :zip=>"94105", :country_code=>"US"}
+    @opencage_city_hash = {:city=>"San Francisco", :state=>"CA"}
+    @opencage_full_loc = Geokit::GeoLoc.new(@opencage_full_hash)
+    @opencage_city_loc = Geokit::GeoLoc.new(@opencage_city_hash)
+
+    # Note: This is not a real key because having real keys on github
+    # is not advised
+    key = 'someopencageapikey'
+    Geokit::Geocoders::OpencageGeocoder.key = key
+
+  end
+
+
+  def test_opencage_full_address
+
+
+    VCR.use_cassette('opencage_full') do
+      url = "https://api.opencagedata.com/geocode/v1/json?key=someopencageapikey&query=100+Spear+St%2C+San+Francisco%2C+CA%2C+94105%2C+US&no_annotations=1"
+      TestHelper.expects(:last_url).with(url)
+      res = Geokit::Geocoders::OpencageGeocoder.geocode(@opencage_full_loc)
+
+      assert_equal "California", res.state
+      assert_equal "San Francisco", res.city
+      assert_array_in_delta [37.7921509, -122.394], res.to_a
+      assert res.is_us?
+      assert_equal "Spear Street 100, San Francisco, California, 94103, US", res.full_address
+      assert_equal "opencage", res.provider
+    end
+  end
+
+
+  def test_opencage_city
+
+    VCR.use_cassette('opencage_city') do
+      url = "https://api.opencagedata.com/geocode/v1/json?key=someopencageapikey&query=San+Francisco%2C+CA&no_annotations=1"
+      TestHelper.expects(:last_url).with(url)
+      res = Geokit::Geocoders::OpencageGeocoder.geocode(@opencage_city_loc)
+
+      assert_equal "California", res.state
+      assert_equal "San Francisco", res.city
+      assert_array_in_delta [37.7792768, -122.4192704], res.to_a
+      assert res.is_us?
+      assert_equal "San Francisco, California, US", res.full_address
+      assert_equal "opencage", res.provider
+    end
+  end
+
+
+  def test_opencage_reverse
+
+    VCR.use_cassette('opencage_reverse_madrid') do
+
+      location = Geokit::GeoLoc.new
+      location.lat, location.lng = "40.4167413", "-3.7032498"     # Madrid
+
+      url = "https://api.opencagedata.com/geocode/v1/json?key=someopencageapikey&query=40.4167413%2C-3.7032498&no_annotations=1"
+      TestHelper.expects(:last_url).with(url)
+      res = Geokit::Geocoders::OpencageGeocoder.geocode(location.ll)
+
+
+      assert_equal "ES", res.country_code
+      assert_equal "opencage", res.provider
+
+      assert_equal "Madrid", res.city
+      assert_equal "Community of Madrid", res.state
+
+      assert_equal "Spain", res.country
+      assert_equal true, res.success
+
+      assert_equal "Calle De Zurbano, Chamberí, Madrid, Community of Madrid, 28036, ES", res.full_address
+      assert_equal 28036, res.zip
+      assert_equal "Calle De Zurbano", res.street_address
+    end
+  end
+
+
+
+  def test_opencage_reverse2
+
+    VCR.use_cassette('opencage_reverse_prilep') do
+
+      location = Geokit::GeoLoc.new
+      location.lat, location.lng = "41.3527177", "21.5497808"
+
+      url = "https://api.opencagedata.com/geocode/v1/json?key=someopencageapikey&query=41.3527177%2C21.5497808&no_annotations=1"
+      TestHelper.expects(:last_url).with(url)
+      res = Geokit::Geocoders::OpencageGeocoder.geocode(location.ll)
+
+      assert_equal "MK", res.country_code
+      assert_equal "opencage", res.provider
+
+      assert_equal "Prilep", res.city
+      assert_equal "Pelagonia Region", res.state
+
+      assert_equal "Macedonia", res.country
+      assert_equal 10, res.precision
+      assert_equal true, res.success
+
+      assert_equal "Прилепски Бранители, Prilep, Pelagonia Region, MK", res.full_address
+      assert_equal "Прилепски Бранители", res.street_address
+    end
+  end
+
+
+  # check if the results are in Spanish if &language=es
+  def test_language_response
+
+    VCR.use_cassette('opencage_language_response_es') do
+      url = "https://api.opencagedata.com/geocode/v1/json?key=someopencageapikey&language=es&query=London&no_annotations=1"
+      TestHelper.expects(:last_url).with(url)
+      language_result = Geokit::Geocoders::OpencageGeocoder.geocode('London', :language => "es")
+
+      assert_equal "Londres", language_result.city
+    end
+  end
+
+end


### PR DESCRIPTION
This adds support for http://geocoder.opencagedata.com/. Tests are using fixtures and all pass. I haven't edited the Changelog or version number.
