### PR TITLE
Make MapBox interface compatible with MultiGeocoder

### DIFF
--- a/lib/geokit/geocoders/mapbox.rb
+++ b/lib/geokit/geocoders/mapbox.rb
@@ -9,7 +9,7 @@ module Geokit
       private
 
       # Template method which does the reverse-geocode lookup.
-      def self.do_reverse_geocode(latlng)
+      def self.do_reverse_geocode(latlng, options = {})
         latlng = LatLng.normalize(latlng)
         url =  "#{protocol}://api.tiles.mapbox.com/v4/geocode/mapbox.places-v1/"
         url += "#{latlng.lng},#{latlng.lat}.json?access_token=#{key}"
@@ -17,7 +17,7 @@ module Geokit
       end
 
       # Template method which does the geocode lookup.
-      def self.do_geocode(address)
+      def self.do_geocode(address, options = {})
         address_str = address.is_a?(GeoLoc) ? address.to_geocodeable_s : address
         url =  "#{protocol}://api.tiles.mapbox.com/v4/geocode/mapbox.places-v1/"
         url += "#{Geokit::Inflector.url_escape(address_str)}.json?access_token=#{key}"

--- a/lib/geokit/multi_geocoder.rb
+++ b/lib/geokit/multi_geocoder.rb
@@ -45,7 +45,7 @@ module Geokit
       # This method will call one or more geocoders in the order specified in
       # the configuration until one of the geocoders work, only this time it's
       # going to try to reverse geocode a geographical point.
-      def self.do_reverse_geocode(latlng)
+      def self.do_reverse_geocode(latlng, *args)
         Geokit::Geocoders.provider_order.each do |provider|
           klass = geocoder(provider)
           begin

--- a/test/test_multi_geocoder.rb
+++ b/test/test_multi_geocoder.rb
@@ -98,4 +98,9 @@ class MultiGeocoderTest < BaseGeocoderTest #:nodoc: all
     Geokit::Geocoders::UsGeocoder.expects(:geocode).never
     assert_equal @success, Geokit::Geocoders::MultiGeocoder.geocode(@address, provider_order: [:yahoo, :google, :us])
   end
+
+  def test_mapbox
+    Geokit::Geocoders::MultiGeocoder.geocode(@address, provider_order: [:mapbox])
+    Geokit::Geocoders::MultiGeocoder.reverse_geocode(@latlng, provider_order: [:mapbox])
+  end
 end


### PR DESCRIPTION
We're using MapBox with the `MultiGeocoder`, and Geokit's MapBox geocoder did not take the second `options` argument used by multi, resulting in errors like

> Caught an error during Mapbox geocoding call: wrong number of arguments (2 for 1)

This PR fixes that by adding the argument to the appropriate methods, and ignoring it.

The tests simply confirm that no error is raised when geocoding with MapBox.