### PR TITLE
Raise error when invalid/unsupported units supplied #157

### DIFF
--- a/lib/geokit/mappable.rb
+++ b/lib/geokit/mappable.rb
@@ -33,10 +33,15 @@ module Geokit
       # :formula - valid values are :flat or :sphere
       # (Geokit::default_formula is the default)
       def distance_between(from, to, options = {})
+        units = options[:units]
+        units = Geokit::default_units if units.nil?
+        [:miles, :kms, :meters, :nms].include?(units) or raise ArgumentError.new(
+          "#{units} is an invalid or unsupported unit of length.")
+
         from = Geokit::LatLng.normalize(from)
         to = Geokit::LatLng.normalize(to)
         return 0.0 if from == to # fixes a "zero-distance" bug
-        units = options[:units] || Geokit.default_units
+
         formula = options[:formula] || Geokit.default_formula
         case formula
         when :sphere then distance_between_sphere(from, to, units)
@@ -86,7 +91,11 @@ module Geokit
       # an endpoint. Returns a LatLng instance. Typically, the instance method
       # will be used instead of this method.
       def endpoint(start, heading, distance, options = {})
-        units   = options[:units] || Geokit.default_units
+        units = options[:units]
+        units = Geokit::default_units if units.nil?
+        [:miles, :kms, :meters, :nms].include?(units) or raise ArgumentError.new(
+          "#{units} is an invalid or unsupported unit of length.")
+
         ratio   = distance.to_f / units_sphere_multiplier(units)
         start   = Geokit::LatLng.normalize(start)
         lat     = deg2rad(start.lat)

--- a/lib/geokit/mappable.rb
+++ b/lib/geokit/mappable.rb
@@ -33,14 +33,9 @@ module Geokit
       # :formula - valid values are :flat or :sphere
       # (Geokit::default_formula is the default)
       def distance_between(from, to, options = {})
-        units = options[:units]
-        units = Geokit::default_units if units.nil?
-        [:miles, :kms, :meters, :nms].include?(units) or
-          raise ArgumentError.new(
-            "#{units} is an invalid or unsupported unit of length.")
-
-        from = Geokit::LatLng.normalize(from)
-        to = Geokit::LatLng.normalize(to)
+        units = get_units!(options)
+        from  = Geokit::LatLng.normalize(from)
+        to    = Geokit::LatLng.normalize(to)
         return 0.0 if from == to # fixes a "zero-distance" bug
 
         formula = options[:formula] || Geokit.default_formula
@@ -92,12 +87,7 @@ module Geokit
       # an endpoint. Returns a LatLng instance. Typically, the instance method
       # will be used instead of this method.
       def endpoint(start, heading, distance, options = {})
-        units = options[:units]
-        units = Geokit::default_units if units.nil?
-        [:miles, :kms, :meters, :nms].include?(units) or
-          raise ArgumentError.new(
-            "#{units} is an invalid or unsupported unit of length.")
-
+        units   = get_units!(options)
         ratio   = distance.to_f / units_sphere_multiplier(units)
         start   = Geokit::LatLng.normalize(start)
         lat     = deg2rad(start.lat)
@@ -188,6 +178,16 @@ module Geokit
       # Returns the number units per longitude degree.
       def units_per_longitude_degree(lat, units)
         units_sphere_multiplier(units) * Math.cos(lat * PI_DIV_RAD) * PI_DIV_RAD
+      end
+
+      # Extracts units from options. Returns Geokit::default_units when not present.
+      # Raise an exception when given unsupported unit of length
+      def get_units!(options = {})
+        units = options[:units]
+        units = Geokit::default_units if units.nil?
+        [:miles, :kms, :meters, :nms].include?(units) or
+          raise ArgumentError, "#{units} is an unsupported unit of length."
+        units
       end
     end
 

--- a/lib/geokit/mappable.rb
+++ b/lib/geokit/mappable.rb
@@ -35,8 +35,9 @@ module Geokit
       def distance_between(from, to, options = {})
         units = options[:units]
         units = Geokit::default_units if units.nil?
-        [:miles, :kms, :meters, :nms].include?(units) or raise ArgumentError.new(
-          "#{units} is an invalid or unsupported unit of length.")
+        [:miles, :kms, :meters, :nms].include?(units) or
+          raise ArgumentError.new(
+            "#{units} is an invalid or unsupported unit of length.")
 
         from = Geokit::LatLng.normalize(from)
         to = Geokit::LatLng.normalize(to)
@@ -93,8 +94,9 @@ module Geokit
       def endpoint(start, heading, distance, options = {})
         units = options[:units]
         units = Geokit::default_units if units.nil?
-        [:miles, :kms, :meters, :nms].include?(units) or raise ArgumentError.new(
-          "#{units} is an invalid or unsupported unit of length.")
+        [:miles, :kms, :meters, :nms].include?(units) or
+          raise ArgumentError.new(
+            "#{units} is an invalid or unsupported unit of length.")
 
         ratio   = distance.to_f / units_sphere_multiplier(units)
         start   = Geokit::LatLng.normalize(start)

--- a/test/test_latlng.rb
+++ b/test/test_latlng.rb
@@ -255,23 +255,17 @@ class LatLngTest < Test::Unit::TestCase #:nodoc: all
     assert_equal 37, dms[2].round
   end
 
-  def test_invalid_or_unsupported_units
-    exception = assert_raise(ArgumentError) do
-      @loc_a.distance_to(@loc_e, units: :invalid_units)
-    end
+  def test_invalid_units
+    expected_exception_message = 'feet is an unsupported unit of length.'
 
-    assert_equal(
-      "invalid_units is an invalid or unsupported unit of length.",
-      exception.message
-    )
+    exception = assert_raise(ArgumentError) do
+      @loc_a.distance_to(@loc_e, units: :feet)
+    end
+    assert_equal expected_exception_message, exception.message
 
     exception = assert_raise(ArgumentError) do
       @loc_a.endpoint(332, 3.97, units: :feet)
     end
-
-    assert_equal(
-      "feet is an invalid or unsupported unit of length.",
-      exception.message
-    )
+    assert_equal expected_exception_message, exception.message
   end
 end

--- a/test/test_latlng.rb
+++ b/test/test_latlng.rb
@@ -254,4 +254,15 @@ class LatLngTest < Test::Unit::TestCase #:nodoc: all
     assert_equal [-87, 39], dms[0, 2]
     assert_equal 37, dms[2].round
   end
+
+  def test_invalid_or_unsupported_units
+    exception = assert_raise(ArgumentError) do
+      @loc_a.distance_to(@loc_e, :units => :invalid_units)
+    end
+    assert_equal "invalid_units is an invalid or unsupported unit of length.", exception.message
+
+    exception = assert_raise(ArgumentError) do
+      @loc_a.endpoint(332, 3.97, :units => :feet)
+    end
+  end
 end

--- a/test/test_latlng.rb
+++ b/test/test_latlng.rb
@@ -257,12 +257,21 @@ class LatLngTest < Test::Unit::TestCase #:nodoc: all
 
   def test_invalid_or_unsupported_units
     exception = assert_raise(ArgumentError) do
-      @loc_a.distance_to(@loc_e, :units => :invalid_units)
+      @loc_a.distance_to(@loc_e, units: :invalid_units)
     end
-    assert_equal "invalid_units is an invalid or unsupported unit of length.", exception.message
+
+    assert_equal(
+      "invalid_units is an invalid or unsupported unit of length.",
+      exception.message
+    )
 
     exception = assert_raise(ArgumentError) do
-      @loc_a.endpoint(332, 3.97, :units => :feet)
+      @loc_a.endpoint(332, 3.97, units: :feet)
     end
+
+    assert_equal(
+      "feet is an invalid or unsupported unit of length.",
+      exception.message
+    )
   end
 end

--- a/test/test_mappable.rb
+++ b/test/test_mappable.rb
@@ -55,4 +55,17 @@ class MappableTest < Test::Unit::TestCase #:nodoc: all
     assert_in_delta 42.573784, TestMappable.units_per_longitude_degree( 45, :nms), delta
     assert_in_delta  0.000000, TestMappable.units_per_longitude_degree( 90, :nms), delta
   end
+
+  def test_get_units
+    units = TestMappable::get_units!
+    assert_equal Geokit::default_units, units
+
+    units = TestMappable::get_units!(units: :miles)
+    assert_equal :miles, units
+
+    exception = assert_raise(ArgumentError) do
+      TestMappable::get_units!(units: :feet)
+    end
+    assert_equal 'feet is an unsupported unit of length.', exception.message
+  end
 end


### PR DESCRIPTION
Use Geokit::default_units only if no units supplied.