### PR TITLE
Added support for the Geobytes geocoder

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in geokit.gemspec
 gemspec
 
+gem 'pry-rails'
 gem 'pry', :platforms => :ruby_19
 gem 'mime-types', '< 2.0', :platforms => :ruby_18
 gem 'geoip' # for testing - only required for max_mind

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in geokit.gemspec
 gemspec
 
-gem 'pry-rails'
 gem 'pry', :platforms => :ruby_19
 gem 'mime-types', '< 2.0', :platforms => :ruby_18
 gem 'geoip' # for testing - only required for max_mind

--- a/README.markdown
+++ b/README.markdown
@@ -58,6 +58,7 @@ Combine this gem with the [geokit-rails](http://github.com/geokit/geokit-rails) 
 ### IP address geocoders
 * IP - geocodes an IP address using hostip.info's web service.
 * Geoplugin.net -- another IP address geocoder
+* Geobytes
 * RIPE
 * MaxMind
 * freegeoip.net

--- a/fixtures/vcr_cassettes/geobytes_geocode.yml
+++ b/fixtures/vcr_cassettes/geobytes_geocode.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://freegeoip.net/xml/12.12.12.12
+    uri: http://getcitydetails.geobytes.com/GetCityDetails?fqcn=12.12.12.12
     body:
       encoding: US-ASCII
       string: ''
@@ -14,32 +14,28 @@ http_interactions:
       User-Agent:
       - Ruby
       Host:
-      - freegeoip.net
+      - getcitydetails.geobytes.com
   response:
     status:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.4.6 (Ubuntu)
       Date:
-      - Sat, 11 Apr 2015 19:16:10 GMT
+      - Sun, 11 Apr 2015 19:52:36 GMT
       Content-Type:
-      - application/xml
+      - application/json
+      Expires:
+      - '0'
       Content-Length:
-      - '399'
-      Connection:
-      - keep-alive
-      Access-Control-Allow-Method:
-      - GET, HEAD, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      X-Database-Date:
-      - Wed, 08 Apr 2015 16:56:28 GMT
+      - '676'
     body:
       encoding: UTF-8
-      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Response>\n\t<IP>12.12.12.12</IP>\n\t<CountryCode>US</CountryCode>\n\t<CountryName>United
-        States</CountryName>\n\t<RegionCode>AK</RegionCode>\n\t<RegionName>Alaska</RegionName>\n\t<City>Anchorage</City>\n\t<ZipCode>99501</ZipCode>\n\t<TimeZone>America/Anchorage</TimeZone>\n\t<Latitude>61.223</Latitude>\n\t<Longitude>-149.853</Longitude>\n\t<MetroCode>743</MetroCode>\n</Response>\n"
+      string: '{"geobytescertainty":"66","geobytesinternet":"US","geobytescountry":"United
+        States","geobytesregionlocationcode":"USNY","geobytesregion":"New York","geobytescode":"NY","geobyteslocationcode":"USNYNYOR","geobytescity":"New
+        York","geobytescityid":"10182","geobytesfqcn":"New York, NY, United States","geobyteslatitude":"40.748798","geobyteslongitude":"-73.984596","geobytescapital":"Washington,
+        DC ","geobytestimezone":"-05:00","geobytesnationalitysingular":"American","geobytespopulation":"278058881","geobytesnationalityplural":"Americans","geobytesmapreference":"North
+        America ","geobytescurrency":"US Dollar","geobytescurrencycode":"USD","geobytestitle":"The
+        United States"}'
     http_version: 
-  recorded_at: Sat, 11 Apr 2015 19:16:11 GMT
+  recorded_at: Sat, 11 Apr 2015 19:52:37 GMT
 recorded_with: VCR 2.9.3

--- a/fixtures/vcr_cassettes/geobytes_geocode.yml
+++ b/fixtures/vcr_cassettes/geobytes_geocode.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://freegeoip.net/xml/12.12.12.12
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+      User-Agent:
+      - Ruby
+      Host:
+      - freegeoip.net
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Sat, 11 Apr 2015 19:16:10 GMT
+      Content-Type:
+      - application/xml
+      Content-Length:
+      - '399'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Method:
+      - GET, HEAD, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      X-Database-Date:
+      - Wed, 08 Apr 2015 16:56:28 GMT
+    body:
+      encoding: UTF-8
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Response>\n\t<IP>12.12.12.12</IP>\n\t<CountryCode>US</CountryCode>\n\t<CountryName>United
+        States</CountryName>\n\t<RegionCode>AK</RegionCode>\n\t<RegionName>Alaska</RegionName>\n\t<City>Anchorage</City>\n\t<ZipCode>99501</ZipCode>\n\t<TimeZone>America/Anchorage</TimeZone>\n\t<Latitude>61.223</Latitude>\n\t<Longitude>-149.853</Longitude>\n\t<MetroCode>743</MetroCode>\n</Response>\n"
+    http_version: 
+  recorded_at: Sat, 11 Apr 2015 19:16:11 GMT
+recorded_with: VCR 2.9.3

--- a/lib/geokit/geocoders/geobytes.rb
+++ b/lib/geokit/geocoders/geobytes.rb
@@ -2,9 +2,6 @@ module Geokit
   module Geocoders
     # Provides geocoding based upon an IP address.  The underlying web service is GeoSelect
     class GeobytesGeocoder < BaseIpGeocoder
-      
-      private
-
       def self.do_geocode(ip)
         process :json, ip
       end
@@ -24,10 +21,8 @@ module Geokit
         loc.precision     = json['geobytescertainty']
         loc.state_name    = json['geobytesregion']
         loc.success       = !json['geobytescity'].empty?
-        
         loc
       end
-
     end
   end
 end

--- a/lib/geokit/geocoders/geobytes.rb
+++ b/lib/geokit/geocoders/geobytes.rb
@@ -1,0 +1,33 @@
+module Geokit
+  module Geocoders
+    # Provides geocoding based upon an IP address.  The underlying web service is GeoSelect
+    class GeobytesGeocoder < BaseIpGeocoder
+      
+      private
+
+      def self.do_geocode(ip)
+        process :json, ip
+      end
+
+      def self.submit_url(ip)
+        "http://getcitydetails.geobytes.com/GetCityDetails?fqcn=#{ip}"
+      end
+
+      def self.parse_json(json)
+        loc = new_loc
+        loc.city          = json['geobytescity']
+        loc.country_code  = json['geobytesinternet']
+        loc.full_address  = json['geobytesfqcn']
+        loc.lat           = json['geobyteslatitude']
+        loc.lng           = json['geobyteslongitude']
+        loc.state         = json['geobytescode']
+        loc.precision     = json['geobytescertainty']
+        loc.state_name    = json['geobytesregion']
+        loc.success       = !json['geobytescity'].empty?
+        
+        loc
+      end
+
+    end
+  end
+end

--- a/test/test_geobytes_geocoder.rb
+++ b/test/test_geobytes_geocoder.rb
@@ -1,5 +1,4 @@
 require File.join(File.dirname(__FILE__), 'helper')
-
 class GeobytesGeocoderTest < BaseGeocoderTest #:nodoc: all
   def setup
     super
@@ -13,13 +12,12 @@ class GeobytesGeocoderTest < BaseGeocoderTest #:nodoc: all
   def test_geobytes_geocoder
     VCR.use_cassette('geobytes_geocode') do
       url = "http://getcitydetails.geobytes.com/GetCityDetails?fqcn=#{@ip}"
-      url = "http://freegeoip.net/xml/#{@ip}"
-    res = Geokit::Geocoders::FreeGeoIpGeocoder.geocode(@ip)
-    assert_url url
-    assert_equal res.city, 'New York'
-    assert_equal res.geobytescode, 'NY'
-    assert_equal res.geobytesinternet, 'US'
-  end
+      res = Geokit::Geocoders::GeobytesGeocoder.geocode(@ip)
+      assert_url url
+      assert_equal res.city, 'New York'
+      assert_equal res.state, 'NY'
+      assert_equal res.country_code, 'US'
+    end
   end
   
 end

--- a/test/test_geobytes_geocoder.rb
+++ b/test/test_geobytes_geocoder.rb
@@ -1,0 +1,25 @@
+require File.join(File.dirname(__FILE__), 'helper')
+
+class GeobytesGeocoderTest < BaseGeocoderTest #:nodoc: all
+  def setup
+    super
+    @ip = '12.12.12.12'
+  end
+  
+  def assert_url(expected_url)
+    assert_equal expected_url, TestHelper.get_last_url.gsub(/&oauth_[a-z_]+=[a-zA-Z0-9\-. %]+/, '').gsub('%20', '+')
+  end
+  
+  def test_geobytes_geocoder
+    VCR.use_cassette('geobytes_geocode') do
+      url = "http://getcitydetails.geobytes.com/GetCityDetails?fqcn=#{@ip}"
+      url = "http://freegeoip.net/xml/#{@ip}"
+    res = Geokit::Geocoders::FreeGeoIpGeocoder.geocode(@ip)
+    assert_url url
+    assert_equal res.city, 'New York'
+    assert_equal res.geobytescode, 'NY'
+    assert_equal res.geobytesinternet, 'US'
+  end
+  end
+  
+end

--- a/test/test_geobytes_geocoder.rb
+++ b/test/test_geobytes_geocoder.rb
@@ -19,5 +19,4 @@ class GeobytesGeocoderTest < BaseGeocoderTest #:nodoc: all
       assert_equal res.country_code, 'US'
     end
   end
-  
 end


### PR DESCRIPTION
This uses the default configuration for Geobyte's Get City Details API. The free service supports up to 50,000 daily queries. Additional query options are also available: http://www.geobytes.com/free-ajax-cities-jsonp-api/#GetCityDetails.