### PR TITLE
BUGFIX use consistent precision names

### DIFF
--- a/lib/geokit/geocoders/google.rb
+++ b/lib/geokit/geocoders/google.rb
@@ -125,6 +125,8 @@ module Geokit
         "APPROXIMATE" => 4,
       }
 
+      PRECISIONS = %w(unknown country state state city zip zip+4 street address building)
+
       def self.single_json_to_geoloc(addr)
         loc = new_loc
         loc.success = true
@@ -188,19 +190,19 @@ module Geokit
 
       def self.set_precision(loc, addr)
         loc.accuracy = ACCURACY[addr["geometry"]["location_type"]]
-        loc.precision = %w(unknown country state state city zip zip+4 street address building)[loc.accuracy]
+        loc.precision = PRECISIONS[loc.accuracy]
         # try a few overrides where we can
         if loc.sub_premise
-          loc.accuracy = 9
-          loc.precision = "building"
+          loc.precision = PRECISIONS[9]
+          loc.accuracy  = 9
         end
         if loc.street_name && loc.precision == "city"
-          loc.precision = "street"
-          loc.accuracy = 7
+          loc.precision = PRECISIONS[7]
+          loc.accuracy  = 7
         end
         if addr["types"].include?("postal_code")
-          loc.precision = "postal_code"
-          loc.accuracy = 6
+          loc.precision = PRECISIONS[6]
+          loc.accuracy  = 6
         end
       end
     end

--- a/test/test_google_geocoder.rb
+++ b/test/test_google_geocoder.rb
@@ -96,6 +96,7 @@ class GoogleGeocoderTest < BaseGeocoderTest #:nodoc: all
     assert_equal "37.7749295,-122.4194155", res.ll
     assert res.is_us?
     assert_equal "San Francisco, CA, USA", res.full_address
+    assert_equal "city", res.precision
     assert_equal "google", res.provider
     end
   end
@@ -112,6 +113,7 @@ class GoogleGeocoderTest < BaseGeocoderTest #:nodoc: all
      assert_equal "40.6745812,-73.9541582", res.ll
      assert res.is_us?
      assert_equal "682 Prospect Place, Brooklyn, NY 11216, USA", res.full_address
+     assert_equal "address", res.precision
      assert_equal "google", res.provider
      end
    end
@@ -128,6 +130,7 @@ class GoogleGeocoderTest < BaseGeocoderTest #:nodoc: all
        assert_equal "42.829583,-73.788174", res.ll
        assert res.is_us?
        assert_equal "8 Barkwood Lane, Clifton Park, NY 12065, USA", res.full_address
+       assert_equal "building", res.precision
        assert_equal "google", res.provider
      end
    end
@@ -135,7 +138,7 @@ class GoogleGeocoderTest < BaseGeocoderTest #:nodoc: all
   def test_google_city_improved_ordering
     VCR.use_cassette("google_city_ordering") do
       res = Geokit::Geocoders::GoogleGeocoder.geocode("62510, fr", bias: "fr")
-
+      assert_equal "zip+4", res.precision
       assert_equal "62510 Arques, France", res.full_address
     end
   end
@@ -145,6 +148,7 @@ class GoogleGeocoderTest < BaseGeocoderTest #:nodoc: all
       url = "https://maps.google.com/maps/api/geocode/json?sensor=false&address=#{Geokit::Inflector.url_escape(@address)}"
     TestHelper.expects(:last_url).with(url)
     res = Geokit::Geocoders::GoogleGeocoder.geocode(@address)
+    assert_equal "city", res.precision
     assert_equal 4, res.accuracy
     end
   end
@@ -160,6 +164,7 @@ class GoogleGeocoderTest < BaseGeocoderTest #:nodoc: all
     assert res.is_us?
     assert_equal "San Francisco, CA, USA", res.full_address
     assert_nil res.street_address
+    assert_equal "city", res.precision
     assert_equal "google", res.provider
     end
   end


### PR DESCRIPTION
We override the result's accuracy if Google returns an address type of "postal_code". When we do so, we set the precision to "postal_code", but we return "zip+4" for the same accuracy level in other cases (without the override check).

This change returns "zip+4" for precision when accuracy is 6, in all cases.