### PR TITLE
Improve handling of Google error responses

### DIFF
--- a/lib/geokit/geocoders.rb
+++ b/lib/geokit/geocoders.rb
@@ -72,6 +72,7 @@ module Geokit
     # Error which is thrown in the event a geocoding error occurs.
     class GeocodeError < StandardError; end
     class TooManyQueriesError < StandardError; end
+    class AccessDeniedError < StandardError; end
 
     # -------------------------------------------------------------------------------------------
     # Geocoder Base class -- every geocoder should inherit from this
@@ -86,7 +87,7 @@ module Geokit
       def self.geocode(address, *args)
         logger.debug "#{provider_name} geocoding. address: #{address}, args #{args}"
         do_geocode(address, *args) || GeoLoc.new
-      rescue TooManyQueriesError, GeocodeError
+      rescue TooManyQueriesError, GeocodeError, AccessDeniedError
         raise
       rescue => e
         logger.error "Caught an error during #{provider_name} geocoding call: #{$!}"

--- a/lib/geokit/geocoders/google.rb
+++ b/lib/geokit/geocoders/google.rb
@@ -86,11 +86,12 @@ module Geokit
 
       def self.parse_json(results)
         case results["status"]
-        when "OVER_QUERY_LIMIT" then raise Geokit::Geocoders::TooManyQueriesError
+        when "OVER_QUERY_LIMIT" then raise Geokit::Geocoders::TooManyQueriesError, results['error_message']
+        when "REQUEST_DENIED" then raise Geokit::Geocoders::AccessDeniedError, results['error_message']
         when "ZERO_RESULTS" then return GeoLoc.new
+        when "OK" then # all good
+        else raise Geokit::Geocoders::GeocodeError, results['error_message']
         end
-        # this should probably be smarter.
-        raise Geokit::Geocoders::GeocodeError if results["status"] != "OK"
 
         unsorted = results["results"].map do |addr|
           single_json_to_geoloc(addr)

--- a/lib/geokit/geocoders/google.rb
+++ b/lib/geokit/geocoders/google.rb
@@ -86,11 +86,16 @@ module Geokit
 
       def self.parse_json(results)
         case results["status"]
-        when "OVER_QUERY_LIMIT" then raise Geokit::Geocoders::TooManyQueriesError, results['error_message']
-        when "REQUEST_DENIED" then raise Geokit::Geocoders::AccessDeniedError, results['error_message']
-        when "ZERO_RESULTS" then return GeoLoc.new
-        when "OK" then # all good
-        else raise Geokit::Geocoders::GeocodeError, results['error_message']
+        when "OVER_QUERY_LIMIT"
+          raise Geokit::Geocoders::TooManyQueriesError, results["error_message"]
+        when "REQUEST_DENIED"
+          raise Geokit::Geocoders::AccessDeniedError, results["error_message"]
+        when "ZERO_RESULTS"
+          return GeoLoc.new
+        when "OK"
+          # all good
+        else
+          raise Geokit::Geocoders::GeocodeError, results["error_message"]
         end
 
         unsorted = results["results"].map do |addr|


### PR DESCRIPTION
- Add a new Geokit::Geocoders::AccessDeniedError
- Raise this error when Google returns REQUEST_DENIED status
- Include message from response when raising exceptions