### PR TITLE
force creation of logger if nil

### DIFF
--- a/lib/geokit/geocoders.rb
+++ b/lib/geokit/geocoders.rb
@@ -102,9 +102,9 @@ module Geokit
         do_reverse_geocode(latlng, *args) || GeoLoc.new
       end
 
-      protected
-
       def self.logger
+        Geokit::Geocoders.logger ||= Logger.new(STDOUT)
+        Geokit::Geocoders.logger.level = Logger::INFO
         Geokit::Geocoders.logger
       end
 


### PR DESCRIPTION
* Logger was nil in ruby 1.9.3.
* This meant that this block just stopped working:

```ruby
      def self.geocode(address, *args)
        logger.debug "#{provider_name} geocoding. address: #{address}, args #{args}"
        do_geocode(address, *args) || GeoLoc.new
      rescue TooManyQueriesError, GeocodeError, AccessDeniedError
        raise
      rescue => e
        logger.error "Caught an error during #{provider_name} geocoding call: #{$!}"
        logger.error e.backtrace.join("\n")
        GeoLoc.new
      end
```

because even the rescue block would throw an exception.

Not sure why no-one else is seeing this. It may have something to do with the fact that we are using `Rails 3.2.17` with an older version of `Mongoid`.

I don't like the solution I've proposed, but can't really follow the logic in the  `self.__define_accessors`. Why is a module_eval needed there? Seems a bit kludgy.

