### PR TITLE
Update Mapbox cassettes to support city-only geocoding queries

### DIFF
--- a/fixtures/vcr_cassettes/mapbox_forward_geocode.yml
+++ b/fixtures/vcr_cassettes/mapbox_forward_geocode.yml
@@ -10,7 +10,7 @@ http_interactions:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
-      - '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
   response:
@@ -21,39 +21,58 @@ http_interactions:
       Content-Type:
       - application/vnd.geo+json; charset=utf-8
       Content-Length:
-      - '1243'
+      - '3143'
       Connection:
       - keep-alive
-      Access-Control-Allow-Methods:
-      - GET
       Access-Control-Allow-Origin:
-      - '*'
+      - "*"
+      Access-Control-Expose-Headers:
+      - x-rate-limit-interval,x-rate-limit-limit,x-rate-limit-remaining,x-rate-limit-reset
       Cache-Control:
       - max-age=3600
       Date:
-      - Thu, 21 Aug 2014 05:42:19 GMT
+      - Wed, 05 Aug 2015 17:05:43 GMT
       Etag:
-      - '"9363c6116c867d7a272693e81eb6c456"'
+      - '"990fe72d1269b3087771d373ba1b92ad"'
       Last-Modified:
-      - Thu, 21 Aug 2014 05:42:19 GMT
-      Server:
-      - nginx
+      - Wed, 05 Aug 2015 17:05:43 GMT
       X-Powered-By:
       - Express
+      X-Rate-Limit-Interval:
+      - '60'
+      X-Rate-Limit-Limit:
+      - '600'
+      X-Rate-Limit-Remaining:
+      - '599'
+      X-Rate-Limit-Reset:
+      - '1438794402'
+      Age:
+      - '104'
       X-Cache:
-      - Miss from cloudfront
+      - Hit from cloudfront
       Via:
-      - 1.1 25e6ff20e328e7479b6db9fee82a8d60.cloudfront.net (CloudFront)
+      - 1.1 7e4ecdff0078259d2c1827ec3336b278.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - QRVX5xyBFaHKip4ALpz6ZPtpDGVGm9FDjn_DleC3PMmCUXyfABDeCw==
+      - LiKAQL5YclcLAX7ysTz4FpZqW2_Ns6PVc_cv6jvqO9XdrZODBmkyUQ==
     body:
       encoding: UTF-8
-      string: '{"type":"FeatureCollection","query":["1714","14th","street","nw","washington","dc"],"features":[{"id":"city.20001","type":"Feature","text":"Washington","place_name":"Washington,
-        20002, District of Columbia, United States","relevance":0.3233333333333333,"center":[-76.992695,38.899393],"geometry":{"type":"Point","coordinates":[-76.992695,38.899393]},"bbox":[-77.11976790632382,38.80310600134152,-76.90938401684849,38.99555498159024],"properties":{"title":"Washington"},"context":[{"id":"postcode-us.3962709191","text":"20002"},{"id":"province.1190806886","text":"District
-        of Columbia"},{"id":"country.4150104525","text":"United States"}]},{"id":"city.21154","type":"Feature","text":"Street","place_name":"Street,
-        21154, Maryland, United States","relevance":0.16666666666666666,"center":[-76.344429,39.645749],"geometry":{"type":"Point","coordinates":[-76.344429,39.645749]},"bbox":[-76.49929286959762,39.59802207980489,-76.22835205150847,39.693469713854434],"properties":{"title":"Street"},"context":[{"id":"postcode-us.2234502147","text":"21154"},{"id":"province.928365533","text":"Maryland"},{"id":"country.4150104525","text":"United
-        States"}]}],"attribution":"<a href=''https://www.mapbox.com/about/maps/''
-        target=''_blank''>&copy; Mapbox</a>"}'
+      string: '{"type":"FeatureCollection","query":["1714","14th","street","nw","washington","dc"],"features":[{"id":"address.75018674165319","type":"Feature","text":"14th
+        St NW","place_name":"1714 14th St NW, Washington, 20009, District of Columbia,
+        United States","relevance":0.9989999999999999,"center":[-77.031952,38.913184],"geometry":{"type":"Point","coordinates":[-77.031952,38.913184],"interpolated":true},"bbox":[-77.03261199999999,38.91112899999999,-77.03183899999996,38.92880499999998],"address":"1714","properties":{},"context":[{"id":"city.20001","text":"Washington"},{"id":"postcode.1308149819","text":"20009"},{"id":"province.1190806886","text":"District
+        of Columbia"},{"id":"country.4150104525","text":"United States"}]},{"id":"address.9831827761295","type":"Feature","text":"14th
+        St NW","place_name":"14th St NW, Washington, 20005, District of Columbia,
+        United States","relevance":0.7323333333333333,"center":[-77.031949,38.904122],"geometry":{"type":"Point","coordinates":[-77.031949,38.904122]},"bbox":[-77.03196299999998,38.89734899999999,-77.03194899999997,38.91112899999999],"properties":{},"context":[{"id":"city.20001","text":"Washington"},{"id":"postcode.4009156820","text":"20005"},{"id":"province.1190806886","text":"District
+        of Columbia"},{"id":"country.4150104525","text":"United States"}]},{"id":"address.206317692383283","type":"Feature","text":"E
+        St NW","place_name":"E St NW, Washington, 20001, District of Columbia, United
+        States","relevance":0.7323333333333333,"center":[-77.017227,38.896133],"geometry":{"type":"Point","coordinates":[-77.017227,38.896133]},"bbox":[-77.03196199999996,38.896104999999984,-77.00905899999995,38.89613699999999],"properties":{},"context":[{"id":"city.20001","text":"Washington"},{"id":"postcode.2700102601","text":"20001"},{"id":"province.1190806886","text":"District
+        of Columbia"},{"id":"country.4150104525","text":"United States"}]},{"id":"address.12847447657866","type":"Feature","text":"14th
+        St NW","place_name":"14th St NW, Washington, 20004, District of Columbia,
+        United States","relevance":0.7323333333333333,"center":[-77.031942,38.893377],"geometry":{"type":"Point","coordinates":[-77.031942,38.893377]},"bbox":[-77.03196699999998,38.89041599999999,-77.03194199999999,38.89734899999999],"properties":{},"context":[{"id":"city.20001","text":"Washington"},{"id":"postcode.858369517","text":"20004"},{"id":"province.1190806886","text":"District
+        of Columbia"},{"id":"country.4150104525","text":"United States"}]},{"id":"address.68742434139344","type":"Feature","text":"S
+        St NW","place_name":"S St NW, Washington, 20001, District of Columbia, United
+        States","relevance":0.7323333333333333,"center":[-77.018178,38.914085],"geometry":{"type":"Point","coordinates":[-77.018178,38.914085]},"bbox":[-77.02703499999998,38.913971999999994,-77.00901299999997,38.91420799999999],"properties":{},"context":[{"id":"city.20001","text":"Washington"},{"id":"postcode.2700102601","text":"20001"},{"id":"province.1190806886","text":"District
+        of Columbia"},{"id":"country.4150104525","text":"United States"}]}],"attribution":"<a
+        href=''https://www.mapbox.com/about/maps/'' target=''_blank''>&copy; Mapbox</a>"}'
     http_version: 
-  recorded_at: Thu, 21 Aug 2014 05:42:19 GMT
-recorded_with: VCR 2.9.2
+  recorded_at: Wed, 05 Aug 2015 17:07:27 GMT
+recorded_with: VCR 2.9.3

--- a/fixtures/vcr_cassettes/mapbox_forward_geocode_city_only.yml
+++ b/fixtures/vcr_cassettes/mapbox_forward_geocode_city_only.yml
@@ -1,0 +1,73 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.tiles.mapbox.com/v4/geocode/mapbox.places-v1/Washington,+DC.json?access_token=
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/vnd.geo+json; charset=utf-8
+      Content-Length:
+      - '2416'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - x-rate-limit-interval,x-rate-limit-limit,x-rate-limit-remaining,x-rate-limit-reset
+      Cache-Control:
+      - max-age=3600
+      Date:
+      - Wed, 05 Aug 2015 16:44:17 GMT
+      Etag:
+      - '"68acbd95bd4b36ee26faa707a34f1631"'
+      Last-Modified:
+      - Wed, 05 Aug 2015 16:44:17 GMT
+      X-Powered-By:
+      - Express
+      X-Rate-Limit-Interval:
+      - '60'
+      X-Rate-Limit-Limit:
+      - '600'
+      X-Rate-Limit-Remaining:
+      - '599'
+      X-Rate-Limit-Reset:
+      - '1438793117'
+      Age:
+      - '1390'
+      X-Cache:
+      - Hit from cloudfront
+      Via:
+      - 1.1 b7fb0f8de9924b1b44ffa1e559f19091.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - JE9owG-k8ZOi37ZOQbXs6jzdELdtEQikt6gtTdlW-iPnKHgaHzCH6Q==
+    body:
+      encoding: UTF-8
+      string: '{"type":"FeatureCollection","query":["washington","dc"],"features":[{"id":"city.20001","type":"Feature","text":"Washington","place_name":"Washington,
+        20004, District of Columbia, United States","relevance":0.999,"center":[-77.0364,38.8951],"geometry":{"type":"Point","coordinates":[-77.0364,38.8951]},"bbox":[-77.1197590084041,38.80311299006593,-76.90939299,38.99554800807594],"properties":{},"context":[{"id":"postcode.858369517","text":"20004"},{"id":"province.1190806886","text":"District
+        of Columbia"},{"id":"country.4150104525","text":"United States"}]},{"id":"province.1190806886","type":"Feature","text":"District
+        of Columbia","place_name":"District of Columbia, United States","relevance":0.49,"center":[-77.009289,38.909152],"geometry":{"type":"Point","coordinates":[-77.009289,38.909152]},"bbox":[-77.11975899999999,38.79164499999999,-76.90939299999997,38.99554799999999],"properties":{},"context":[{"id":"country.4150104525","text":"United
+        States"}]},{"id":"city.39246","type":"Feature","text":"Washington","place_name":"Washington,
+        Sunderland, United Kingdom","relevance":0.49,"center":[-1.519344,54.904404],"geometry":{"type":"Point","coordinates":[-1.519344,54.904404]},"bbox":[-1.572074,54.873852,-1.471309,54.935104],"properties":{},"context":[{"id":"province.972624862","text":"Sunderland"},{"id":"country.2794958072","text":"United
+        Kingdom"}]},{"id":"city.39247","type":"Feature","text":"Washington","place_name":"Washington,
+        West Sussex, United Kingdom","relevance":0.49,"center":[-0.393505,50.888378],"geometry":{"type":"Point","coordinates":[-0.393505,50.888378]},"bbox":[-0.42587,50.86474599999999,-0.3537509999999999,50.916752],"properties":{},"context":[{"id":"province.2373165042","text":"West
+        Sussex"},{"id":"country.2794958072","text":"United Kingdom"}]},{"id":"address.56461051138823","type":"Feature","text":"Washington","place_name":"Washington,
+        Irvine, 92606, California, United States","relevance":0.39,"center":[-117.792586,33.71292],"geometry":{"type":"Point","coordinates":[-117.792586,33.71292]},"bbox":[-117.79281099999997,33.711665999999994,-117.791035,33.714770999999985],"properties":{},"context":[{"id":"city.92602","text":"Irvine"},{"id":"postcode.1397213125","text":"92606"},{"id":"province.1112151813","text":"California"},{"id":"country.4150104525","text":"United
+        States"}]}],"attribution":"<a href=''https://www.mapbox.com/about/maps/''
+        target=''_blank''>&copy; Mapbox</a>"}'
+    http_version: 
+  recorded_at: Wed, 05 Aug 2015 17:07:27 GMT
+recorded_with: VCR 2.9.3

--- a/fixtures/vcr_cassettes/mapbox_reverse_geocode.yml
+++ b/fixtures/vcr_cassettes/mapbox_reverse_geocode.yml
@@ -10,7 +10,7 @@ http_interactions:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
-      - '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
   response:
@@ -21,43 +21,53 @@ http_interactions:
       Content-Type:
       - application/vnd.geo+json; charset=utf-8
       Content-Length:
-      - '1902'
+      - '2408'
       Connection:
       - keep-alive
-      Access-Control-Allow-Methods:
-      - GET
       Access-Control-Allow-Origin:
-      - '*'
+      - "*"
+      Access-Control-Expose-Headers:
+      - x-rate-limit-interval,x-rate-limit-limit,x-rate-limit-remaining,x-rate-limit-reset
       Cache-Control:
       - max-age=3600
       Date:
-      - Thu, 21 Aug 2014 05:46:02 GMT
+      - Wed, 05 Aug 2015 17:05:43 GMT
       Etag:
-      - '"90af4b2c9697b67786ad9039a4174ff1"'
+      - '"990fe72d1269b3087771d373ba1b92ad"'
       Last-Modified:
-      - Thu, 21 Aug 2014 05:46:02 GMT
-      Server:
-      - nginx
+      - Wed, 05 Aug 2015 17:05:43 GMT
       X-Powered-By:
       - Express
+      X-Rate-Limit-Interval:
+      - '60'
+      X-Rate-Limit-Limit:
+      - '600'
+      X-Rate-Limit-Remaining:
+      - '598'
+      X-Rate-Limit-Reset:
+      - '1438794403'
+      Age:
+      - '104'
       X-Cache:
-      - Miss from cloudfront
+      - Hit from cloudfront
       Via:
-      - 1.1 565d425ab1cf4d8d6fb4c465f8b73889.cloudfront.net (CloudFront)
+      - 1.1 bd90418f9d3315c701732d0fc172cfc6.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - 8KyW9WZU-vDaHl2_CwBdm0F-eiOtOKIUOnRSgiE3MBU4vnHikk_rUA==
+      - hhva3mOpSO_ZfHDs2ie3vaxjhQtmommN_UTrOx9tHi8MV5Xtpl19XA==
     body:
       encoding: UTF-8
-      string: '{"type":"FeatureCollection","query":[-77.032458,38.913175],"features":[{"id":"city.20001","type":"Feature","text":"Washington","place_name":"Washington,
-        20009, District of Columbia, United States","relevance":1,"center":[-76.992695,38.899393],"geometry":{"type":"Point","coordinates":[-76.992695,38.899393]},"bbox":[-77.11976790632382,38.80310600134152,-76.90938401684849,38.99555498159024],"properties":{"title":"Washington"},"context":[{"id":"postcode-us.1308149819","text":"20009"},{"id":"province.1190806886","text":"District
-        of Columbia"},{"id":"country.4150104525","text":"United States"}]},{"id":"postcode-us.1308149819","type":"Feature","text":"20009","place_name":"20009,
-        District of Columbia, United States","relevance":1,"center":[-77.038291,38.920148],"geometry":{"type":"Point","coordinates":[-77.038291,38.920148]},"bbox":[-77.050216,38.911122999999996,-77.02703300000002,38.92974399999999],"properties":{"title":"20009"},"context":[{"id":"province.1190806886","text":"District
+      string: '{"type":"FeatureCollection","query":[-77.032458,38.913175],"features":[{"id":"address.75018674165319","type":"Feature","text":"14th
+        St NW","place_name":"1712 14th St NW, Washington, 20009, District of Columbia,
+        United States","relevance":1,"center":[-77.03195228861863,38.91313455636009],"geometry":{"type":"Point","coordinates":[-77.03195228861863,38.91313455636009]},"bbox":[-77.03261199999999,38.91112899999999,-77.03183899999996,38.92880499999998],"address":1712,"properties":{},"context":[{"id":"city.20001","text":"Washington"},{"id":"postcode.1308149819","text":"20009"},{"id":"province.1190806886","text":"District
+        of Columbia"},{"id":"country.4150104525","text":"United States"}]},{"id":"city.20001","type":"Feature","text":"Washington","place_name":"Washington,
+        20009, District of Columbia, United States","relevance":1,"center":[-77.0364,38.8951],"geometry":{"type":"Point","coordinates":[-77.0364,38.8951]},"bbox":[-77.1197590084041,38.80311299006593,-76.90939299,38.99554800807594],"properties":{},"context":[{"id":"postcode.1308149819","text":"20009"},{"id":"province.1190806886","text":"District
+        of Columbia"},{"id":"country.4150104525","text":"United States"}]},{"id":"postcode.1308149819","type":"Feature","text":"20009","place_name":"20009,
+        District of Columbia, United States","relevance":1,"center":[-77.038293,38.92017],"geometry":{"type":"Point","coordinates":[-77.038293,38.92017]},"bbox":[-77.05021599999999,38.911125,-77.027035,38.929744],"properties":{},"context":[{"id":"province.1190806886","text":"District
         of Columbia"},{"id":"country.4150104525","text":"United States"}]},{"id":"province.1190806886","type":"Feature","text":"District
-        of Columbia","place_name":"District of Columbia, United States","relevance":1,"center":[-76.987826,38.893698],"geometry":{"type":"Point","coordinates":[-76.987826,38.893698]},"bbox":[-77.119759,38.791644999999995,-76.90939299999998,38.99554799999999],"properties":{"title":"District
-        of Columbia"},"context":[{"id":"country.4150104525","text":"United States"}]},{"id":"country.4150104525","type":"Feature","text":"United
-        States","place_name":"United States","relevance":1,"center":[-99.041476,37.940855],"geometry":{"type":"Point","coordinates":[-99.041476,37.940855]},"bbox":[-179.23108600000003,18.865459999999985,179.85968099999997,71.441059],"properties":{"title":"United
-        States"}}],"attribution":"<a href=''https://www.mapbox.com/about/maps/'' target=''_blank''>&copy;
-        Mapbox</a>"}'
+        of Columbia","place_name":"District of Columbia, United States","relevance":1,"center":[-77.009289,38.909152],"geometry":{"type":"Point","coordinates":[-77.009289,38.909152]},"bbox":[-77.11975899999999,38.79164499999999,-76.90939299999997,38.99554799999999],"properties":{},"context":[{"id":"country.4150104525","text":"United
+        States"}]},{"id":"country.4150104525","type":"Feature","text":"United States","place_name":"United
+        States","relevance":1,"center":[-98.958425,36.778951],"geometry":{"type":"Point","coordinates":[-98.958425,36.778951]},"bbox":[-179.23023299999997,18.866158999999996,179.85968099999994,71.43776899999999],"properties":{}}],"attribution":"<a
+        href=''https://www.mapbox.com/about/maps/'' target=''_blank''>&copy; Mapbox</a>"}'
     http_version: 
-  recorded_at: Thu, 21 Aug 2014 05:46:00 GMT
-recorded_with: VCR 2.9.2
+  recorded_at: Wed, 05 Aug 2015 17:07:27 GMT
+recorded_with: VCR 2.9.3

--- a/lib/geokit/geocoders/mapbox.rb
+++ b/lib/geokit/geocoders/mapbox.rb
@@ -58,15 +58,17 @@ module Geokit
               loc.state = context["text"]
             elsif context["id"] =~ /^city\./
               loc.city = context["text"]
-            elsif context["id"] =~ /^postcode-/
+            elsif context["id"] =~ /^postcode/
               loc.zip = context["text"]
-              loc.country_code = context["id"].split(".")[0].gsub(/^postcode-/, "").upcase
             end
           end
           loc.country = loc.country_code if loc.country_code && !loc.country
         end
         if result_json["place_name"]
           loc.full_address = result_json["place_name"]
+        end
+        if !loc.city && result_json["id"] =~ /^city\./
+          loc.city = result_json["text"]
         end
       end
 

--- a/test/test_mapbox_geocoder.rb
+++ b/test/test_mapbox_geocoder.rb
@@ -7,25 +7,38 @@ class MapboxGeocoderTest < BaseGeocoderTest #:nodoc: all
     super
     @address = "1714 14th Street NW, Washington, DC"
     @latlng = Geokit::LatLng.new(38.913175, -77.032458)
+    @city = "Washington, DC"
   end
 
   def test_forward_geocode
     VCR.use_cassette("mapbox_forward_geocode") do
       res = Geokit::Geocoders::MapboxGeocoder.geocode(@address)
-      assert_equal res.lat, 38.899393
-      assert_equal res.lng, -76.992695
-      assert_equal res.country_code, "US"
-      assert_equal res.state, "District of Columbia"
-      assert_equal res.zip, "20002"
+      assert_equal 38.913184, res.lat
+      assert_equal(-77.031952, res.lng)
+      assert_equal "United States", res.country
+      assert_equal "District of Columbia", res.state
+      assert_equal "20009", res.zip
     end
   end
 
   def test_reverse_geocode
     VCR.use_cassette("mapbox_reverse_geocode") do
       res = Geokit::Geocoders::MapboxGeocoder.reverse_geocode(@latlng)
-      assert_equal res.country_code, "US"
-      assert_equal res.state, "District of Columbia"
-      assert_equal res.zip, "20009"
+      assert_equal "United States", res.country
+      assert_equal "District of Columbia", res.state
+      assert_equal "20009", res.zip
+    end
+  end
+
+  def test_city_only
+    VCR.use_cassette("mapbox_forward_geocode_city_only") do
+      res = Geokit::Geocoders::MapboxGeocoder.geocode(@city)
+      assert_equal 38.8951, res.lat
+      assert_equal(-77.0364, res.lng)
+      assert_equal "United States", res.country
+      assert_equal "District of Columbia", res.state
+      assert_equal "Washington", res.city
+      assert_equal "20004", res.zip
     end
   end
 end


### PR DESCRIPTION
Fixes #173 

Note that mapbox has removed any notion of `country_code` from their responses :(