### PR TITLE
adds support for google-specific place_id and formatted_address

### DIFF
--- a/fixtures/vcr_cassettes/google_full_v3_20.yml
+++ b/fixtures/vcr_cassettes/google_full_v3_20.yml
@@ -1,0 +1,123 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://maps.google.com/maps/api/geocode/json?address=100%20Spear%20St%20Apt.%205,%20San%20Francisco,%20CA,%2094105,%20US&sensor=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Wed, 12 Aug 2015 20:07:52 GMT
+      Expires:
+      - Thu, 13 Aug 2015 20:07:52 GMT
+      Cache-Control:
+      - public, max-age=86400
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - mafe
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+      Accept-Ranges:
+      - none
+      Vary:
+      - Accept-Language,Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+           "results" : [
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "5",
+                       "short_name" : "5",
+                       "types" : [ "subpremise" ]
+                    },
+                    {
+                       "long_name" : "100",
+                       "short_name" : "100",
+                       "types" : [ "street_number" ]
+                    },
+                    {
+                       "long_name" : "Spear Street",
+                       "short_name" : "Spear St",
+                       "types" : [ "route" ]
+                    },
+                    {
+                       "long_name" : "South Beach",
+                       "short_name" : "South Beach",
+                       "types" : [ "neighborhood", "political" ]
+                    },
+                    {
+                       "long_name" : "San Francisco",
+                       "short_name" : "SF",
+                       "types" : [ "locality", "political" ]
+                    },
+                    {
+                       "long_name" : "San Francisco County",
+                       "short_name" : "San Francisco County",
+                       "types" : [ "administrative_area_level_2", "political" ]
+                    },
+                    {
+                       "long_name" : "California",
+                       "short_name" : "CA",
+                       "types" : [ "administrative_area_level_1", "political" ]
+                    },
+                    {
+                       "long_name" : "United States",
+                       "short_name" : "US",
+                       "types" : [ "country", "political" ]
+                    },
+                    {
+                       "long_name" : "94105",
+                       "short_name" : "94105",
+                       "types" : [ "postal_code" ]
+                    }
+                 ],
+                 "formatted_address" : "100 Spear Street #5, San Francisco, CA 94105, USA",
+                 "geometry" : {
+                    "location" : {
+                       "lat" : 37.7920876,
+                       "lng" : -122.3938666
+                    },
+                    "location_type" : "ROOFTOP",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : 37.7934365802915,
+                          "lng" : -122.3925176197085
+                       },
+                       "southwest" : {
+                          "lat" : 37.7907386197085,
+                          "lng" : -122.3952155802915
+                       }
+                    }
+                 },
+                 "partial_match" : true,
+                 "place_id" : "EjExMDAgU3BlYXIgU3RyZWV0ICM1LCBTYW4gRnJhbmNpc2NvLCBDQSA5NDEwNSwgVVNB",
+                 "types" : [ "subpremise" ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version: 
+  recorded_at: Wed, 12 Aug 2015 20:07:52 GMT
+recorded_with: VCR 2.9.3

--- a/lib/geokit/geo_loc.rb
+++ b/lib/geokit/geo_loc.rb
@@ -33,7 +33,8 @@ module Geokit
     # successful geocode lookups. The provider will be set to the name of the
     # providing geocoder. Finally, precision is an indicator of the accuracy of
     # the geocoding.
-    attr_accessor :success, :provider, :precision, :suggested_bounds
+    attr_accessor :success, :provider, :precision, :suggested_bounds, :place_id,
+                  :formatted_address
     # accuracy is set for Yahoo and Google geocoders, it is a numeric value of
     # the precision. see
     # http://code.google.com/apis/maps/documentation/geocoding/#GeocodingAccuracy
@@ -92,6 +93,11 @@ module Geokit
     def street_name
       @street_name ||= street_address[street_number.length, street_address.length].strip if street_address
       @street_name
+    end
+
+    # Returns Google-supplied normalized address string or concatenation of address parts
+    def formatted_address
+      @formatted_address ||= full_address
     end
 
     # gives you all the important fields as key-value pairs

--- a/lib/geokit/geocoders/google.rb
+++ b/lib/geokit/geocoders/google.rb
@@ -150,6 +150,9 @@ module Geokit
 
         set_bounds(loc, addr)
 
+        loc.place_id = addr['place_id']
+        loc.formatted_address = addr['formatted_address']
+
         loc
       end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -39,8 +39,6 @@ require "test/unit"
 require "mocha/setup"
 require "net/http"
 
-require 'openssl'
-
 require File.join(File.dirname(__FILE__), "../lib/geokit.rb")
 
 class MockSuccess < Net::HTTPSuccess #:nodoc: all

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -39,6 +39,8 @@ require "test/unit"
 require "mocha/setup"
 require "net/http"
 
+require 'openssl'
+
 require File.join(File.dirname(__FILE__), "../lib/geokit.rb")
 
 class MockSuccess < Net::HTTPSuccess #:nodoc: all

--- a/test/test_geoloc.rb
+++ b/test/test_geoloc.rb
@@ -44,6 +44,15 @@ class GeoLocTest < Test::Unit::TestCase #:nodoc: all
     assert_equal "Irving, TX, 75063, US", @loc.full_address
   end
 
+  def test_formatted_address
+    @loc.formatted_address = nil
+    @loc.full_address = "Irving, TX, 75063, US"
+    assert_equal "Irving, TX, 75063, US", @loc.formatted_address
+    @loc.formatted_address = "San Francisco, CA, 94105, US"
+    @loc.full_address = "Irving, TX, 75063, US"
+    assert_equal "San Francisco, CA, 94105, US", @loc.formatted_address
+  end
+
   def test_hash
     @loc.city = "San Francisco"
     @loc.state = "CA"

--- a/test/test_google_geocoder.rb
+++ b/test/test_google_geocoder.rb
@@ -190,6 +190,24 @@ class GoogleGeocoderTest < BaseGeocoderTest #:nodoc: all
     Geokit::Geocoders::GoogleGeocoder.geocode("Winnetka", bias: bounds)
   end
 
+  def test_google_place_id
+    VCR.use_cassette("google_full_v3_20") do
+      url = "https://maps.google.com/maps/api/geocode/json?sensor=false&address=#{Geokit::Inflector.url_escape(@full_address_short_zip)}"
+      TestHelper.expects(:last_url).with(url)
+      res = Geokit::Geocoders::GoogleGeocoder.geocode(@full_address_short_zip)
+      assert_equal 'EjExMDAgU3BlYXIgU3RyZWV0ICM1LCBTYW4gRnJhbmNpc2NvLCBDQSA5NDEwNSwgVVNB', res.place_id
+    end
+  end
+
+  def test_google_formatted_address
+    VCR.use_cassette("google_full_v3_20") do
+      url = "https://maps.google.com/maps/api/geocode/json?sensor=false&address=#{Geokit::Inflector.url_escape(@full_address_short_zip)}"
+      TestHelper.expects(:last_url).with(url)
+      res = Geokit::Geocoders::GoogleGeocoder.geocode(@full_address_short_zip)
+      assert_equal '100 Spear Street #5, San Francisco, CA 94105, USA', res.formatted_address
+    end
+  end
+
   def test_service_unavailable
     response = MockFailure.new
     url = "https://maps.google.com/maps/api/geocode/json?sensor=false&address=#{Geokit::Inflector.url_escape(@address)}"


### PR DESCRIPTION
This is not a best way to support provider-specific data but I'm not sure whether it is in geokit philosophy to provide for this kind of variation in the first place. Although there is some google-specific support already, so why not bring more? 
As a cleaner approach I'd suggest creating a container attribute in GeoLoc, named e.g. `custom` and keep there a hash/structured object with provider-specific data. This way top level GeoLoc structure would be more consistent while permitting more flexibility in returned data contents.