### PR TITLE
Timeout error deprecated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
   - 2.0
   - 2.1
   - 2.2
+  - 2.3
 script: "bundle exec rake coverage"
 before_install:
   - gem install bundler

--- a/lib/geokit/geocoders.rb
+++ b/lib/geokit/geocoders.rb
@@ -138,7 +138,7 @@ module Geokit
       def self.call_geocoder_service(url)
         Timeout.timeout(Geokit::Geocoders.request_timeout) { return do_get(url) } if Geokit::Geocoders.request_timeout
         do_get(url)
-      rescue TimeoutError
+      rescue Timeout::Error
         nil
       end
 


### PR DESCRIPTION
After upgrade to Ruby 2.3.0 I was getting `warning: constant Geokit::Geocoders::Geocoder::TimeoutError is deprecated`.

This should be safe to merge. I checked and `Timeout::Error` is supported all the way down to 1.8.7 :)

<img width="510" alt="screen_shot_2016-03-24_at_15_17_28" src="https://cloud.githubusercontent.com/assets/5148/14019555/ad7e9668-f1d3-11e5-9f84-9111695bd057.png">

Cheers
Vlado
