### PR TITLE
Update Mapbox geocoder to handle geocoding State only values

### DIFF
--- a/lib/geokit/geocoders/mapbox.rb
+++ b/lib/geokit/geocoders/mapbox.rb
@@ -70,6 +70,9 @@ module Geokit
         if !loc.city && result_json["id"] =~ /^city\./
           loc.city = result_json["text"]
         end
+        if !loc.state && result_json["id"] =~ /^province\./
+          loc.state = result_json["text"]
+        end
       end
 
       PRECISION_VALUES = %w(unknown country state city zip full_address)

--- a/test/test_mapbox_geocoder.rb
+++ b/test/test_mapbox_geocoder.rb
@@ -8,6 +8,7 @@ class MapboxGeocoderTest < BaseGeocoderTest #:nodoc: all
     @address = "1714 14th Street NW, Washington, DC"
     @latlng = Geokit::LatLng.new(38.913175, -77.032458)
     @city = "Washington, DC"
+    @state = "District of Columbia"
 
     Geokit::Geocoders::MapboxGeocoder.key = @keys['mapbox']['key']
   end
@@ -41,6 +42,18 @@ class MapboxGeocoderTest < BaseGeocoderTest #:nodoc: all
       assert_equal "District of Columbia", res.state
       assert_equal "Washington", res.city
       assert_equal "20004", res.zip
+    end
+  end
+
+  def test_state_only
+    VCR.use_cassette("mapbox_forward_geocode_state_only") do
+      res = Geokit::Geocoders::MapboxGeocoder.geocode(@state)
+      assert_equal 38.89657, res.lat
+      assert_equal(-76.990661, res.lng)
+      assert_equal "United States", res.country
+      assert_equal "District of Columbia", res.state
+      assert_nil res.city
+      assert_nil res.zip
     end
   end
 end


### PR DESCRIPTION
In this case, like when geocoding City only values, the Mapbox response has the State value at the higher level.