### PR TITLE
Optional config parameter for user-agent header, alias for OSMGeocoder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ nbproject
 Gemfile.lock
 *.idea
 coverage
+.ruby-gemset
+.ruby-version

--- a/README.markdown
+++ b/README.markdown
@@ -45,13 +45,14 @@ Combine this gem with the [geokit-rails](http://github.com/geokit/geokit-rails) 
 * Yandex
 * MapQuest
 * Geocod.io
+* OpenStreetMap (Nominatim)
 * Mapbox - requires an access token
 * [OpenCage](http://geocoder.opencagedata.com) - requires an API key
 
 ### address geocoders that also provide reverse geocoding
 * Google - Supports multiple results and bounding box/country code biasing.  Also supports Maps API for Business keys; see the configuration section below.
 * FCC
-* OpenStreetMap
+* OpenStreetMap (Nominatim)
 * Mapbox
 * OpenCage
 
@@ -120,6 +121,10 @@ If you're using this gem by itself, here are the configuration options:
     # filled in at a minimum.  If the proxy requires authentication, the username
     # and password can be provided as well.
     Geokit::Geocoders::proxy = 'https://user:password@host:port'
+
+    # This setting can be used if a web service blocks requests by certain user agents.
+    # If not set Geokit uses the default useragent header set by the different net adapter libs.
+    Geokit::Geocoders::useragent = 'my agent string'
 
     # This is your yahoo application key for the Yahoo Geocoder.
     # See http://developer.yahoo.com/faq/index.html#appid
@@ -263,12 +268,13 @@ Multi Geocoder - provides failover for the physical location geocoders, and also
     Geokit::Geocoders::MultiGeocoder.geocode("900 Sycamore Drive")
 
     Geokit::Geocoders::MultiGeocoder.geocode("12.12.12.12")
+
+    Geokit::Geocoders::MultiGeocoder.geocode("Hamburg, Germany", :provider_order => [:osm, :mapbox, :google])
 ```
 
 ## MULTIPLE RESULTS
 Some geocoding services will return multple results if the there isn't one clear result.
-Geoloc can capture multiple results through its "all" method. Currently only the Google geocoder
-supports multiple results:
+Geoloc can capture multiple results through its "all" method.
 
 ```ruby
     irb> geo=Geokit::Geocoders::GoogleGeocoder.geocode("900 Sycamore Drive")

--- a/lib/geokit/geocoders.rb
+++ b/lib/geokit/geocoders.rb
@@ -33,6 +33,7 @@ module Geokit
   # Some of these geocoders require configuration. You don't have to provide it here. See the README.
   module Geocoders
     @@proxy = nil
+    @@useragent = nil
     @@request_timeout = nil
     @@provider_order = [:google, :us]
     @@ip_provider_order = [:geo_plugin, :ip]

--- a/lib/geokit/geocoders/bing.rb
+++ b/lib/geokit/geocoders/bing.rb
@@ -9,7 +9,7 @@ module Geokit
       private
 
       # Template method which does the geocode lookup.
-      def self.do_geocode(address)
+      def self.do_geocode(address, options = {})
         url = submit_url(address)
         res = call_geocoder_service(url)
         return GeoLoc.new unless net_adapter.success?(res)

--- a/lib/geokit/geocoders/openstreetmap.rb
+++ b/lib/geokit/geocoders/openstreetmap.rb
@@ -110,4 +110,6 @@ module Geokit
       end
     end
   end
+
+  Geokit::Geocoders::OsmGeocoder = Geokit::Geocoders::OSMGeocoder
 end

--- a/lib/geokit/multi_geocoder.rb
+++ b/lib/geokit/multi_geocoder.rb
@@ -45,8 +45,10 @@ module Geokit
       # This method will call one or more geocoders in the order specified in
       # the configuration until one of the geocoders work, only this time it's
       # going to try to reverse geocode a geographical point.
-      def self.do_reverse_geocode(latlng, *_args)
-        Geokit::Geocoders.provider_order.each do |provider|
+      def self.do_reverse_geocode(latlng, *args)
+        provider_order = provider_order_for(latlng, args)
+
+        provider_order.each do |provider|
           klass = geocoder(provider)
           begin
             res = klass.send :reverse_geocode, latlng

--- a/lib/geokit/net_adapter/net_http.rb
+++ b/lib/geokit/net_adapter/net_http.rb
@@ -3,7 +3,8 @@ module Geokit
     class NetHttp
       def self.do_get(url)
         uri = URI(url)
-        req = Net::HTTP::Get.new(uri.request_uri)
+        Geokit::Geocoders.useragent ? headers = {'User-Agent' => Geokit::Geocoders.useragent} : headers = {} 
+        req = Net::HTTP::Get.new(uri.request_uri, headers)
         req.basic_auth(uri.user, uri.password) if uri.userinfo
         net_http_args = [uri.host, uri.port]
         if (proxy_uri_string = Geokit::Geocoders.proxy)

--- a/lib/geokit/net_adapter/typhoeus.rb
+++ b/lib/geokit/net_adapter/typhoeus.rb
@@ -2,7 +2,8 @@ module Geokit
   module NetAdapter
     class Typhoeus
       def self.do_get(url)
-        ::Typhoeus.get(url.to_s)
+        Geokit::Geocoders.useragent ? headers = {'User-Agent' => Geokit::Geocoders.useragent} : headers = {}
+        ::Typhoeus.get(url.to_s, :headers => headers)
       end
 
       def self.success?(response)

--- a/lib/geokit/net_adapter/typhoeus.rb
+++ b/lib/geokit/net_adapter/typhoeus.rb
@@ -2,7 +2,7 @@ module Geokit
   module NetAdapter
     class Typhoeus
       def self.do_get(url)
-        Geokit::Geocoders.useragent ? headers = {'User-Agent' => Geokit::Geocoders.useragent} : headers = {}
+        headers = Geokit::Geocoders.useragent ? {'User-Agent' => Geokit::Geocoders.useragent} : {}
         ::Typhoeus.get(url.to_s, :headers => headers)
       end
 

--- a/test/test_useragent.rb
+++ b/test/test_useragent.rb
@@ -1,0 +1,46 @@
+require 'test/unit'
+require 'webmock/test_unit'
+
+require File.join(File.dirname(__FILE__), '../lib/geokit.rb')
+
+class UserAgentTest < Test::Unit::TestCase
+
+    NETHTTPDEFAULT          = 'Ruby'
+    NETHTTPDEFAULTHEADERS   = {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3'}
+    TYPHOEUSDEFAULT         = 'Typhoeus - https://github.com/typhoeus/typhoeus'
+    TYPHOEUSDEFAULTHEADERS  = {'Expect'=>''}
+    TESTAGENT               = 'MyAgent'
+    URL                     = 'http://www.example.com'
+
+    def test_nethttp_useragent_set_to_testagent
+        stub_request(:get, URL).with(:headers => NETHTTPDEFAULTHEADERS.merge('User-Agent' => TESTAGENT))
+
+        Geokit::Geocoders::useragent = TESTAGENT
+        Geokit::NetAdapter::NetHttp.do_get(URL)
+        assert_requested :get, URL
+    end
+
+    def test_nethttp_useragent_set_to_default
+        stub_request(:get, URL).with(:headers => NETHTTPDEFAULTHEADERS.merge('User-Agent' => NETHTTPDEFAULT))
+
+        Geokit::Geocoders::useragent = nil
+        Geokit::NetAdapter::NetHttp.do_get(URL)
+        assert_requested :get, URL
+    end
+
+    def test_typhoeus_set_to_testagent
+        stub_request(:get, URL).with(:headers => TYPHOEUSDEFAULTHEADERS.merge('User-Agent' => TESTAGENT))
+
+        Geokit::Geocoders::useragent = TESTAGENT
+        Geokit::NetAdapter::Typhoeus.do_get(URL)
+        assert_requested :get, URL
+    end
+
+    def test_typhoeus_set_to_default
+        stub_request(:get, URL).with(:headers => TYPHOEUSDEFAULTHEADERS.merge('User-Agent' => TYPHOEUSDEFAULT))
+
+        Geokit::Geocoders::useragent = nil
+        Geokit::NetAdapter::Typhoeus.do_get(URL)
+        assert_requested :get, URL
+    end
+end


### PR DESCRIPTION
Made the following changes regarding issue #194 :
- new optional parameter Geokit::Geocoders::useragent
- send user agent header for both net adapters
- some small readme changes

Sorry for not providing any tests, but I was having some issues with 

```
rake test
```

and as I am not familiar with vcr and simplecov, I was not very keen to debug the issue :-)

Additionally I created a new alias OsmGeocoder because of the following error in Multigeocoding with OSM:

```
E, [2016-10-27T17:37:51.610364 #9174] ERROR -- : Caught an error during Multi geocoding call: uninitialized constant Geokit::Geocoders::OsmGeocoder
E, [2016-10-27T17:37:51.610421 #9174] ERROR -- : /Users/co/projects/geokit/lib/geokit/multi_geocoder.rb:65:in `const_get'
/Users/co/projects/geokit/lib/geokit/multi_geocoder.rb:65:in `geocoder'
/Users/co/projects/geokit/lib/geokit/multi_geocoder.rb:32:in `block in do_geocode'
/Users/co/projects/geokit/lib/geokit/multi_geocoder.rb:31:in `each'
/Users/co/projects/geokit/lib/geokit/multi_geocoder.rb:31:in `do_geocode'
/Users/co/projects/geokit/lib/geokit/geocoders.rb:90:in `geocode'
```
