### PR TITLE
Google optional reverse parameters

### DIFF
--- a/lib/geokit/geocoders/google.rb
+++ b/lib/geokit/geocoders/google.rb
@@ -69,8 +69,10 @@ module Geokit
       end
 
       def self.submit_url(query_string, options = {})
+        location_type_str = options[:location_type] ? "&location_type=#{options[:location_type]}" : ''
+        result_type_str = options[:result_type] ? "&result_type=#{options[:result_type]}" : ''
         language_str = options[:language] ? "&language=#{options[:language]}" : ''
-        query_string = "/maps/api/geocode/json?sensor=false&#{query_string}#{language_str}"
+        query_string = "/maps/api/geocode/json?sensor=false&#{query_string}#{location_type_str}#{result_type_str}#{language_str}"
         if client_id && cryptographic_key
           channel_string = channel ? "&channel=#{channel}" : ''
           urlToSign = query_string + "&client=#{client_id}" + channel_string

--- a/lib/geokit/geocoders/google.rb
+++ b/lib/geokit/geocoders/google.rb
@@ -10,7 +10,10 @@ module Geokit
       # * :language - See: https://developers.google.com/maps/documentation/geocoding
       def self.do_reverse_geocode(latlng, options = {})
         latlng = LatLng.normalize(latlng)
-        url = submit_url("latlng=#{Geokit::Inflector.url_escape(latlng.ll)}", options)
+        latlng_str = "latlng=#{Geokit::Inflector.url_escape(latlng.ll)}"
+        result_type_str = options[:result_type] ? "&result_type=#{options[:result_type]}" : ''
+        location_type_str = options[:location_type] ? "&location_type=#{options[:location_type]}" : ''
+        url = submit_url("#{latlng_str}#{result_type_str}#{location_type_str}", options)
         process :json, url
       end
 
@@ -69,10 +72,8 @@ module Geokit
       end
 
       def self.submit_url(query_string, options = {})
-        location_type_str = options[:location_type] ? "&location_type=#{options[:location_type]}" : ''
-        result_type_str = options[:result_type] ? "&result_type=#{options[:result_type]}" : ''
         language_str = options[:language] ? "&language=#{options[:language]}" : ''
-        query_string = "/maps/api/geocode/json?sensor=false&#{query_string}#{location_type_str}#{result_type_str}#{language_str}"
+        query_string = "/maps/api/geocode/json?sensor=false&#{query_string}#{language_str}"
         if client_id && cryptographic_key
           channel_string = channel ? "&channel=#{channel}" : ''
           urlToSign = query_string + "&client=#{client_id}" + channel_string

--- a/lib/geokit/geocoders/google.rb
+++ b/lib/geokit/geocoders/google.rb
@@ -8,6 +8,12 @@ module Geokit
 
       # ==== OPTIONS
       # * :language - See: https://developers.google.com/maps/documentation/geocoding
+      # * :result_type - This option allows restricting results by specific result types.
+      #                  See https://developers.google.com/maps/documentation/geocoding/intro#reverse-restricted
+      #                  Note: This parameter is available only for requests that include an API key or a client ID.
+      # * :location_type - This option allows restricting results by specific location type.
+      #                    See https://developers.google.com/maps/documentation/geocoding/intro#reverse-restricted
+      #                    Note: This parameter is available only for requests that include an API key or a client ID.
       def self.do_reverse_geocode(latlng, options = {})
         latlng = LatLng.normalize(latlng)
         latlng_str = "latlng=#{Geokit::Inflector.url_escape(latlng.ll)}"


### PR DESCRIPTION
In order to support `result_type` and `location_type` [optional parameters](https://developers.google.com/maps/documentation/geocoding/intro#ReverseGeocoding) we've modified the `do_reverse_geocode` class method. This change allows to get results by granularity. 
For example, you can request just neighborhood results. If you are interested in this PR we can add some tests, but we'll need a Google API key.
