### PR TITLE
Make sure all geocoders have same do_geocode method signature

### DIFF
--- a/lib/geokit/geocoders/bing.rb
+++ b/lib/geokit/geocoders/bing.rb
@@ -9,7 +9,7 @@ module Geokit
       private
 
       # Template method which does the geocode lookup.
-      def self.do_geocode(address)
+      def self.do_geocode(address, _=nil)
         url = submit_url(address)
         res = call_geocoder_service(url)
         return GeoLoc.new unless net_adapter.success?(res)

--- a/lib/geokit/geocoders/ca_geocoder.rb
+++ b/lib/geokit/geocoders/ca_geocoder.rb
@@ -17,7 +17,7 @@ module Geokit
       private
 
       # Template method which does the geocode lookup.
-      def self.do_geocode(loc)
+      def self.do_geocode(loc, _=nil)
         process :xml, submit_url(loc), GeoLoc.new
       end
 

--- a/lib/geokit/geocoders/free_geo_ip.rb
+++ b/lib/geokit/geocoders/free_geo_ip.rb
@@ -4,7 +4,7 @@ module Geokit
     class FreeGeoIpGeocoder < BaseIpGeocoder
       private
 
-      def self.do_geocode(ip)
+      def self.do_geocode(ip, _=nil)
         process :xml, ip
       end
 

--- a/lib/geokit/geocoders/geo_plugin.rb
+++ b/lib/geokit/geocoders/geo_plugin.rb
@@ -4,7 +4,7 @@ module Geokit
     class GeoPluginGeocoder < BaseIpGeocoder
       private
 
-      def self.do_geocode(ip)
+      def self.do_geocode(ip, _=nil)
         process :xml, ip
       end
 

--- a/lib/geokit/geocoders/geobytes.rb
+++ b/lib/geokit/geocoders/geobytes.rb
@@ -2,7 +2,7 @@ module Geokit
   module Geocoders
     # Provides geocoding based upon an IP address.  The underlying web service is GeoSelect
     class GeobytesGeocoder < BaseIpGeocoder
-      def self.do_geocode(ip)
+      def self.do_geocode(ip, _=nil)
         process :json, ip
       end
 

--- a/lib/geokit/geocoders/geocodio.rb
+++ b/lib/geokit/geocoders/geocodio.rb
@@ -5,7 +5,7 @@ module Geokit
 
       private
 
-      def self.do_geocode(address)
+      def self.do_geocode(address, _=nil)
         process :json, submit_url(address)
       end
 

--- a/lib/geokit/geocoders/geonames.rb
+++ b/lib/geokit/geocoders/geonames.rb
@@ -8,7 +8,7 @@ module Geokit
       private
 
       # Template method which does the geocode lookup.
-      def self.do_geocode(address)
+      def self.do_geocode(address, _=nil)
         process :xml, submit_url(address)
       end
 

--- a/lib/geokit/geocoders/ip.rb
+++ b/lib/geokit/geocoders/ip.rb
@@ -9,7 +9,7 @@ module Geokit
       # Given an IP address, returns a GeoLoc instance which contains latitude,
       # longitude, city, and country code.  Sets the success attribute to false if the ip
       # parameter does not match an ip address.
-      def self.do_geocode(ip)
+      def self.do_geocode(ip, _=nil)
         return GeoLoc.new unless valid_ip?(ip)
         url = submit_url(ip)
         res = call_geocoder_service(url)

--- a/lib/geokit/geocoders/mapquest.rb
+++ b/lib/geokit/geocoders/mapquest.rb
@@ -16,7 +16,7 @@ module Geokit
       end
 
       # Template method which does the geocode lookup.
-      def self.do_geocode(address)
+      def self.do_geocode(address, _=nil)
         address_str = address.is_a?(GeoLoc) ? address.to_geocodeable_s : address
         url = "#{protocol}://www.mapquestapi.com/geocoding/v1/address?key=#{key}&location=#{Geokit::Inflector.url_escape(address_str)}"
         process :json, url

--- a/lib/geokit/geocoders/maxmind.rb
+++ b/lib/geokit/geocoders/maxmind.rb
@@ -6,7 +6,7 @@ module Geokit
 
       private
 
-      def self.do_geocode(ip)
+      def self.do_geocode(ip, _=nil)
         res = GeoIP.new(geoip_data_path).city(ip)
 
         loc = new_loc

--- a/lib/geokit/geocoders/ripe.rb
+++ b/lib/geokit/geocoders/ripe.rb
@@ -6,7 +6,7 @@ module Geokit
 
       private
 
-      def self.do_geocode(ip)
+      def self.do_geocode(ip, _=nil)
         process :json, ip
       end
 

--- a/lib/geokit/geocoders/us_geocoder.rb
+++ b/lib/geokit/geocoders/us_geocoder.rb
@@ -8,7 +8,7 @@ module Geokit
 
       private
 
-      def self.do_geocode(address)
+      def self.do_geocode(address, _=nil)
         process :csv, submit_url(address)
       end
 

--- a/lib/geokit/geocoders/yahoo.rb
+++ b/lib/geokit/geocoders/yahoo.rb
@@ -21,7 +21,7 @@ module Geokit
       end
 
       # Template method which does the geocode lookup.
-      def self.do_geocode(address)
+      def self.do_geocode(address, _=nil)
         process :json, submit_url(address)
       end
 

--- a/lib/geokit/geocoders/yandex.rb
+++ b/lib/geokit/geocoders/yandex.rb
@@ -8,7 +8,7 @@ module Geokit
       private
 
       # Template method which does the geocode lookup.
-      def self.do_geocode(address)
+      def self.do_geocode(address, _=nil)
         process :json, submit_url(address)
       end
 


### PR DESCRIPTION
When using ```MultiGeocoder.do_geocode``` it will call ```.do_geocode(address, *args)``` on different geocoders.

However most geocoders implement ```do_geocode(address)``` and not ```do_geocode(address, args)```.
As a result you will see "wrong number of arguments (2 for 1)" errors in your logs.

This PR should fix that issue.