### PR TITLE
Update "valid symbols are..." in README for provider_order

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -187,13 +187,19 @@ If you're using this gem by itself, here are the configuration options:
 
     # This is the order in which the geocoders are called in a failover scenario
     # If you only want to use a single geocoder, put a single symbol in the array.
-    # Valid symbols are :google, :yahoo, :us, and :ca.
+    #
+    # Valid symbols are: :bing, :ca, :fcc, :geocodio, :geonames, :google,
+    # :map_quest, :mapbox, :maxmind, :opencage, :osm, :us, :yahoo, and :yandex.
+    #
     # Be aware that there are Terms of Use restrictions on how you can use the
     # various geocoders.  Make sure you read up on relevant Terms of Use for each
     # geocoder you are going to use.
     Geokit::Geocoders::provider_order = [:google,:us]
 
-    # The IP provider order. Valid symbols are :ip,:geo_plugin.
+    # The IP provider order.
+    #
+    # Valid symbols are :free_geo_ip, :geo_plugin, :geobytes, :ip, and :ripe.
+    #
     # As before, make sure you read up on relevant Terms of Use for each.
     # Geokit::Geocoders::ip_provider_order = [:external,:geo_plugin,:ip]
 


### PR DESCRIPTION
I generated the list with this code, so it should be accurate:

    irb(main):002:0> Geokit::Geocoders.constants.map { |sym| Geokit::Geocoders.const_get sym }.select { |klass| klass.superclass == Geokit::Geocoders::Geocoder }.reject { |klass| klass == Geokit::Geocoders::BaseIpGeocoder }.map { |klass| Geokit::Inflector.underscore(klass.provider_name).to_sym }.map(&:inspect).uniq.sort.reject { |s| s == ":multi" }.join(", ")
    => ":bing, :ca, :fcc, :geocodio, :geonames, :google, :map_quest, :mapbox, :maxmind, :opencage, :osm, :us, :yahoo, :yandex"
    
    irb(main):003:0> Geokit::Geocoders.constants.map { |sym| Geokit::Geocoders.const_get sym }.select { |klass| klass.superclass == Geokit::Geocoders::BaseIpGeocoder }.map { |klass| Geokit::Inflector.underscore(klass.provider_name).to_sym }.map(&:inspect).uniq.sort.join(", ")
    => ":free_geo_ip, :geo_plugin, :geobytes, :ip, :ripe"

I wanted to add something along those lines as a method on `Geokit::Geocoders` so that, even if the README got out of date again, developers could easily get a list of providers to check against.

In fact the current method of just assigning a new array to `provider_order` could be replaced with a setter that would check the list was completely valid and raise an exception if not.

But I didn't do that because the code I ended up with is fairly nasty :sweat_smile: Especially the explicit removal of the MultiGeocoder itself from the list of providers. Am I missing a trick there? You could have something like `self.provider = true` and `self.ip_provider = true`, in the same way that secure support is currently handled.

If this is something you'd like to explore further let me know :+1: 