### PR TITLE
Initial implementation for IP-API.com geocoder

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -214,7 +214,7 @@ Style/Lambda:
 
 # Offense count: 4
 # Cop supports --auto-correct.
-Style/MethodCallParentheses:
+Style/MethodCallWithoutArgsParentheses:
   Exclude:
     - 'test/test_maxmind_geocoder.rb'
 

--- a/README.markdown
+++ b/README.markdown
@@ -63,6 +63,7 @@ Combine this gem with the [geokit-rails](http://github.com/geokit/geokit-rails) 
 * RIPE
 * MaxMind
 * freegeoip.net
+* IP-API.com
 
 ### HTTPS-supporting geocoders
 * Google

--- a/fixtures/vcr_cassettes/ip_api_geocode.yml
+++ b/fixtures/vcr_cassettes/ip_api_geocode.yml
@@ -1,0 +1,35 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://ip-api.com/json/74.125.237.209
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sat, 23 Sep 2017 04:40:17 GMT
+      Content-Length:
+      - '287'
+    body:
+      encoding: UTF-8
+      string: '{"as":"AS15169 Google Inc.","city":"Mountain View","country":"United
+        States","countryCode":"US","isp":"Google","lat":37.4192,"lon":-122.0574,"org":"Google","query":"74.125.237.209","region":"CA","regionName":"California","status":"success","timezone":"America/Los_Angeles","zip":"94043"}'
+    http_version: 
+  recorded_at: Sat, 23 Sep 2017 04:34:33 GMT
+recorded_with: VCR 3.0.3

--- a/lib/geokit/geocoders.rb
+++ b/lib/geokit/geocoders.rb
@@ -26,6 +26,7 @@ module Geokit
   # ### IP address geocoders
   # * IP Geocoder - geocodes an IP address using hostip.info's web service.
   # * Geoplugin.net -- another IP address geocoder
+  # * IP-API.com -- another IP address geocoder
   #
   # ### The Multigeocoder
   # * Multi Geocoder - provides failover for the physical location geocoders.

--- a/lib/geokit/geocoders/ip_api_geocoder.rb
+++ b/lib/geokit/geocoders/ip_api_geocoder.rb
@@ -1,0 +1,31 @@
+module Geokit
+  module Geocoders
+    # Provides geocoding based upon an IP address.  The underlying web service is ip-api.com
+    class IpApiGeocoder < BaseIpGeocoder
+      private
+
+      def self.do_geocode(ip, _=nil)
+        process :json, ip
+      end
+
+      def self.submit_url(ip)
+        "http://ip-api.com/json/#{ip}"
+      end
+
+      def self.parse_json(result)
+        loc = new_loc
+        return loc unless result['status'] == 'success'
+
+        loc.success = true
+        loc.city = result['city']
+        loc.state = result['region']
+        loc.state_name = result['regionName']
+        loc.zip = result['zip']
+        loc.lat = result['lat']
+        loc.lng = result['lon']
+        loc.country_code = result['countryCode']
+        loc
+      end
+    end
+  end
+end

--- a/test/test_ip_api_geocoder.rb
+++ b/test/test_ip_api_geocoder.rb
@@ -1,0 +1,23 @@
+require File.join(File.dirname(__FILE__), 'helper')
+
+class IpApiGeocoderTest < BaseGeocoderTest #:nodoc: all
+  def setup
+    super
+    @ip = '74.125.237.209'
+  end
+
+  def assert_url(expected_url)
+    assert_equal expected_url, TestHelper.last_url
+  end
+
+  def test_free_geo_ip_geocode
+    url = "http://ip-api.com/json/#{@ip}"
+    res = geocode(@ip, :ip_api_geocode)
+    assert_url url
+    assert_equal res.city, 'Mountain View'
+    assert_equal res.state, 'CA'
+    assert_equal res.state_name, 'California'
+    assert_equal res.zip, '94043'
+    assert_equal res.country_code, 'US'
+  end
+end


### PR DESCRIPTION
I wanted to play around in this gem and made this. I'm not sure if you guys are interested but I figured I'll throw it up.

I tested basic equality between freegeoip & ip-api:

irb(main):015:0> Geokit::Geocoders::IpApiGeocoder.geocode('13.107.21.200')
=> #<Geokit::GeoLoc:0x00000001e406c8 @all=[#<Geokit::GeoLoc:0x00000001e406c8 ...>], @street_address=nil, @sub_premise=nil, @street_number=nil, @street_name=nil, @city="Redmond", @state="WA", @state_code=nil, @state_name="Washington", @zip="98052", @country_code="US", @success=true, @precision="unknown", @full_address=nil, @lat=47.6801, @lng=-122.1206, @provider="ip_api">

irb(main):016:0> Geokit::Geocoders::FreeGeoIpGeocoder.geocode('13.107.21.200')
=> #<Geokit::GeoLoc:0x00000001b40a68 @all=[#<Geokit::GeoLoc:0x00000001b40a68 ...>], @street_address=nil, @sub_premise=nil, @street_number=nil, @street_name=nil, @city="Redmond", @state="WA", @state_code=nil, @state_name=nil, @zip="98052", @country_code="US", @success=true, @precision="unknown", @full_address=nil, @lat=47.6801, @lng=-122.1206, @provider="free_geo_ip">

Let me know! Thanks!
