### PR TITLE
Update URL for FCC Geocoding

### DIFF
--- a/fixtures/vcr_cassettes/fcc_reverse_geocode.yml
+++ b/fixtures/vcr_cassettes/fcc_reverse_geocode.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://data.fcc.gov/api/block/find?format=json&latitude=34.05&longitude=-118.25
+    uri: https://geo.fcc.gov/api/census/block/find?format=json&latitude=34.05&longitude=-118.25
     body:
       encoding: US-ASCII
       string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
-      - '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
   response:
@@ -18,22 +18,36 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - Sun-Java-System-Web-Server/7.0
       Date:
-      - Sun, 26 Jan 2014 05:57:32 GMT
+      - Wed, 06 Jun 2018 23:16:19 GMT
       Content-Type:
-      - application/json
-      Via:
-      - 1.1 https-data
-      Proxy-Agent:
-      - Sun-Java-System-Web-Server/7.0
-      Transfer-Encoding:
-      - chunked
+      - application/json; charset=utf-8
+      Content-Length:
+      - '318'
+      Connection:
+      - keep-alive
+      Server:
+      - Apache
+      Access-Control-Allow-Origin:
+      - "*"
+      Etag:
+      - W/"1b9-TirplOWInFVSA/jLG2kuS95iDQU"
+      X-Content-Type-Options:
+      - nosniff
+      X-Dns-Prefetch-Control:
+      - 'off'
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
     body:
       encoding: UTF-8
-      string: '{"Block":{"FIPS":"060372073012003"},"County":{"FIPS":"06037","name":"Los
-        Angeles"},"State":{"FIPS":"06","code":"CA","name":"California"},"status":"OK","executionTime":"11"}'
+      string: '{"messages":["FCC0001: The coordinate lies on the boundary of mulitple
+        blocks, the block contains the clicked location is selected. For a complete
+        list use showall=true to display ''intersection'' element in the Block"],"Block":{"FIPS":"060372073012003","bbox":[-118.250429,34.049521,-118.248017,34.051658]},"County":{"FIPS":"06037","name":"Los
+        Angeles"},"State":{"FIPS":"06","code":"CA","name":"California"},"status":"OK","executionTime":"0"}'
     http_version: 
-  recorded_at: Sun, 26 Jan 2014 05:57:38 GMT
-recorded_with: VCR 2.8.0
+  recorded_at: Wed, 06 Jun 2018 23:16:19 GMT
+recorded_with: VCR 4.0.0

--- a/lib/geokit/geocoders/fcc.rb
+++ b/lib/geokit/geocoders/fcc.rb
@@ -8,7 +8,7 @@ module Geokit
       # Template method which does the reverse-geocode lookup.
       def self.do_reverse_geocode(latlng)
         latlng = LatLng.normalize(latlng)
-        url = "#{protocol}://data.fcc.gov/api/block/find?format=json&latitude=#{Geokit::Inflector.url_escape(latlng.lat.to_s)}&longitude=#{Geokit::Inflector.url_escape(latlng.lng.to_s)}"
+        url = "#{protocol}://geo.fcc.gov/api/census/block/find?format=json&latitude=#{Geokit::Inflector.url_escape(latlng.lat.to_s)}&longitude=#{Geokit::Inflector.url_escape(latlng.lng.to_s)}"
         process :json, url
       end
 

--- a/test/test_fcc_geocoder.rb
+++ b/test/test_fcc_geocoder.rb
@@ -4,7 +4,7 @@ class FCCGeocoderTest < BaseGeocoderTest #:nodoc: all
   def setup
     super
     @la = Geokit::LatLng.new(34.05, -118.25)
-    @base_url = 'https://data.fcc.gov/api/block/find'
+    @base_url = 'https://geo.fcc.gov/api/census/block/find'
   end
 
   def assert_url(expected_url)


### PR DESCRIPTION
The FCC geocoding API has changed. The old URL is not working. This PR updates to the new URL. Here are the new API docs:
  https://geo.fcc.gov/api/census/#!/block/get_block_find