### PR TITLE
Remove `has_rdoc` to clean the deprecation warning

### DIFF
--- a/geokit.gemspec
+++ b/geokit.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'http://github.com/geokit/geokit'
   spec.license       = 'MIT'
 
-  spec.has_rdoc = true
   spec.rdoc_options = ['--main', 'README.markdown']
   spec.extra_rdoc_files = ['README.markdown']
 


### PR DESCRIPTION
It removes the deprecation warning while installing this gem.

```bash
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.
Gem::Specification#has_rdoc= called from /bundle/bundler/gems/geokit-758aaeac0d88/geokit.gemspec:16.
```

See https://blog.rubygems.org/2011/03/28/1.7.0-released.html for the deprecation notice.