### PR TITLE
Add `county` as a new geoloc attribute

### DIFF
--- a/lib/geokit/geo_loc.rb
+++ b/lib/geokit/geo_loc.rb
@@ -25,7 +25,7 @@ module Geokit
     # 100 Spear St, San Francisco, CA, 94101, US
     # Street number and street name are extracted from the street address
     # attribute if they don't exist
-    attr_accessor :state_name, :state_code, :zip, :country_code, :country
+    attr_accessor :county, :state_name, :state_code, :zip, :country_code, :country
     attr_accessor :all, :district, :sub_premise,
                   :neighborhood
     attr_writer :state, :full_address, :street_number, :street_name, :formatted_address
@@ -58,6 +58,7 @@ module Geokit
       @street_number = nil
       @street_name = nil
       @city = h[:city]
+      @county = h[:county]
       @state = h[:state]
       @state_code = h[:state_code]
       @state_name = h[:state_name]
@@ -109,9 +110,9 @@ module Geokit
     # gives you all the important fields as key-value pairs
     def hash
       res = {}
-      fields = [:success, :lat, :lng, :country_code, :city, :state, :zip,
-       :street_address, :district, :provider, :full_address, :is_us?,
-       :ll, :precision, :district_fips, :state_fips, :block_fips, :sub_premise]
+      fields = %i[success lat lng country_code city county state zip
+       street_address district provider full_address is_us?
+       ll precision district_fips state_fips block_fips sub_premise]
       fields.each { |s| res[s] = send(s.to_s) }
       res
     end
@@ -133,8 +134,8 @@ module Geokit
     end
 
     # Returns a comma-delimited string consisting of the street address, city,
-    # state, zip, and country code.  Only includes those attributes that are
-    # non-blank.
+    # state, zip, and country code. Only includes those attributes
+    # that are non-blank.
     def to_geocodeable_s
       a = [street_address, district, city, state, zip, country_code].compact
       a.delete_if { |e| !e || e == '' }
@@ -156,6 +157,7 @@ module Geokit
       ["Provider: #{provider}",
        "Street: #{street_address}",
        "City: #{city}",
+       "County: #{county}",
        "State: #{state}",
        "Zip: #{zip}",
        "Latitude: #{lat}",

--- a/lib/geokit/geocoders/fcc.rb
+++ b/lib/geokit/geocoders/fcc.rb
@@ -38,6 +38,7 @@ module Geokit
         loc.country_code  = 'US'
         loc.district      = results['County']['name']
         loc.district_fips = results['County']['FIPS']
+        loc.county        = results['County']['name']
         loc.state         = results['State']['code']
         loc.state_fips    = results['State']['FIPS']
         loc.block_fips    = results['Block']['FIPS']

--- a/lib/geokit/geocoders/google.rb
+++ b/lib/geokit/geocoders/google.rb
@@ -216,6 +216,7 @@ module Geokit
             loc.country = comp['long_name']
           when types.include?('administrative_area_level_2')
             loc.district = comp['long_name']
+            loc.county = comp['long_name']
           when types.include?('neighborhood')
             loc.neighborhood = comp['short_name']
           # Use either sublocality or admin area level 3 if google does not return a city

--- a/lib/geokit/geocoders/opencage.rb
+++ b/lib/geokit/geocoders/opencage.rb
@@ -74,6 +74,7 @@ module Geokit
         loc.country        = address_data['country']
         loc.country_code   = address_data['country_code'].upcase if address_data['country_code']
         loc.state_name     = address_data['state']
+        loc.county         = address_data['county']
         loc.city           = address_data['city']
         loc.city           = address_data['county'] if loc.city.nil? && address_data['county']
         loc.zip            = address_data['postcode']

--- a/lib/geokit/geocoders/openstreetmap.rb
+++ b/lib/geokit/geocoders/openstreetmap.rb
@@ -84,6 +84,7 @@ module Geokit
         loc.country = address_data['country']
         loc.country_code = address_data['country_code'].upcase if address_data['country_code']
         loc.state_name = address_data['state']
+        loc.county = address_data['county']
         loc.city = address_data['city']
         loc.city = address_data['county'] if loc.city.nil? && address_data['county']
         loc.zip = address_data['postcode']

--- a/test/test_fcc_geocoder.rb
+++ b/test/test_fcc_geocoder.rb
@@ -17,6 +17,7 @@ class FCCGeocoderTest < BaseGeocoderTest #:nodoc: all
     assert_url url
     assert_equal res.country_code, 'US'
     assert_equal res.state, 'CA'
+    assert_equal res.county, 'Los Angeles'
     assert_equal res.district, 'Los Angeles'
   end
 end

--- a/test/test_geo_loc.rb
+++ b/test/test_geo_loc.rb
@@ -88,6 +88,7 @@ class GeoLocTest < Test::Unit::TestCase #:nodoc: all
     assert_equal [
       'city', 'San Francisco',
       'country_code', 'US',
+      'county', '',
       'full_address', '',
       'lat', '',
       'lng', '',

--- a/test/test_google_geocoder.rb
+++ b/test/test_google_geocoder.rb
@@ -118,6 +118,7 @@ class GoogleGeocoderTest < BaseGeocoderTest #:nodoc: all
     res = geocode(@address, :google_city)
     assert_nil res.street_address
     assert_equal 'CA', res.state
+    assert_equal 'San Francisco County', res.county
     assert_equal 'San Francisco', res.city
     assert_equal '37.7749295,-122.4194155', res.ll
     assert res.is_us?
@@ -133,6 +134,7 @@ class GoogleGeocoderTest < BaseGeocoderTest #:nodoc: all
      res = geocode(@address, :google_sublocality)
      assert_equal '682 Prospect Place', res.street_address
      assert_equal 'NY', res.state
+     assert_equal 'Kings County', res.county
      assert_equal 'Brooklyn', res.city
      assert_equal '40.6745812,-73.9541582', res.ll
      assert res.is_us?
@@ -148,6 +150,7 @@ class GoogleGeocoderTest < BaseGeocoderTest #:nodoc: all
      res = geocode(@address, :google_administrative_area_level_3)
      assert_equal '8 Barkwood Lane', res.street_address
      assert_equal 'NY', res.state
+     assert_equal 'Saratoga County', res.county
      assert_equal 'Clifton Park', res.city
      assert_equal '42.829583,-73.788174', res.ll
      assert res.is_us?
@@ -175,6 +178,7 @@ class GoogleGeocoderTest < BaseGeocoderTest #:nodoc: all
     TestHelper.expects(:last_url).with(url)
     res = geocode(@google_city_loc, :google_city)
     assert_equal 'CA', res.state
+    assert_equal 'San Francisco County', res.county
     assert_equal 'San Francisco', res.city
     assert_equal '37.7749295,-122.4194155', res.ll
     assert res.is_us?
@@ -261,6 +265,7 @@ class GoogleGeocoderTest < BaseGeocoderTest #:nodoc: all
     assert_equal 'google', res.provider
 
     assert_equal 'Madrid', res.city
+    assert_equal 'Madrid', res.county
     assert_equal 'Community of Madrid', res.state
 
     assert_equal 'Spain', res.country

--- a/test/test_opencage_geocoder.rb
+++ b/test/test_opencage_geocoder.rb
@@ -22,6 +22,7 @@ class OpencageGeocoderTest < BaseGeocoderTest #:nodoc: all
     res = geocode(@opencage_full_loc, :opencage_full)
 
     assert_equal 'California', res.state
+    assert_equal 'San Francisco City and County', res.county
     assert_equal 'San Francisco', res.city
     assert_array_in_delta [37.7921509, -122.394], res.to_a
     assert res.is_us?
@@ -35,6 +36,7 @@ class OpencageGeocoderTest < BaseGeocoderTest #:nodoc: all
     res = geocode(@opencage_city_loc, :opencage_city)
 
     assert_equal 'California', res.state
+    assert_equal 'San Francisco City and County', res.county
     assert_equal 'San Francisco', res.city
     assert_array_in_delta [37.7792768, -122.4192704], res.to_a
     assert res.is_us?
@@ -55,12 +57,13 @@ class OpencageGeocoderTest < BaseGeocoderTest #:nodoc: all
 
     assert_equal 'Chamberí', res.neighborhood
     assert_equal 'Madrid', res.city
+    assert_equal 'Área metropolitana de Madrid y Corredor del Henares', res.county
     assert_equal 'Community of Madrid', res.state
 
     assert_equal 'Spain', res.country
     assert_equal true, res.success
 
-    assert_equal "Calle De Zurbano, Chamberí, Madrid, Community of Madrid, 28036, ES", res.full_address
+    assert_equal 'Calle De Zurbano, Chamberí, Madrid, Community of Madrid, 28036, ES', res.full_address
     assert_equal 28_036, res.zip
     assert_equal 'Calle De Zurbano', res.street_address
   end
@@ -79,13 +82,15 @@ class OpencageGeocoderTest < BaseGeocoderTest #:nodoc: all
     assert_equal 'Жабино Маало', res.neighborhood
     assert_equal 'Prilep', res.city
     assert_equal 'Pelagonia Region', res.state
+    assert_equal 'Municipality of Prilep', res.county
+    assert_equal 'Prilep', res.city
 
     assert_equal 'Macedonia', res.country
     assert_equal 10, res.precision
     assert_equal true, res.success
 
-    assert_equal "Прилепски Бранители, Prilep, Pelagonia Region, MK", res.full_address
-    assert_equal "Прилепски Бранители", res.street_address
+    assert_equal 'Прилепски Бранители, Prilep, Pelagonia Region, MK', res.full_address
+    assert_equal 'Прилепски Бранители', res.street_address
   end
 
   # check if the results are in Spanish if &language=es

--- a/test/test_openstreetmap_geocoder.rb
+++ b/test/test_openstreetmap_geocoder.rb
@@ -103,6 +103,7 @@ class OSMGeocoderTest < BaseGeocoderTest #:nodoc: all
       assert_equal 'osm', res.provider
 
       assert_equal 'Prilep', res.city
+      assert_equal nil, res.county
       assert_nil res.state
 
       assert_equal 'Macedonia', res.country
@@ -127,6 +128,7 @@ class OSMGeocoderTest < BaseGeocoderTest #:nodoc: all
     assert_equal 'osm', res.provider
 
     assert_equal 'Madrid', res.city
+    assert_equal 'Madrid', res.county
     assert_equal 'Madrid', res.state
 
     assert_equal 'Spain', res.country


### PR DESCRIPTION
It adds a new `geoloc` attribute called **county**. This geographical region is used in a lot of countries as you can see [here](https://en.wikipedia.org/wiki/County).