### PR TITLE
Add neighborhood support for OpenCage

### DIFF
--- a/lib/geokit/geocoders/opencage.rb
+++ b/lib/geokit/geocoders/opencage.rb
@@ -79,7 +79,8 @@ module Geokit
         loc.zip            = address_data['postcode']
         loc.district       = address_data['city_district']
         loc.district       = address_data['state_district'] if loc.district.nil? && address_data['state_district']
-        loc.neighborhood   = address_data['suburb']
+        loc.neighborhood   = address_data['neighbourhood']
+        loc.neighborhood   = address_data['suburb'] if loc.neighborhood.nil?
         loc.street_address = "#{address_data['road']} #{address_data['house_number']}".strip if address_data['road']
         loc.street_name    = address_data['road']
         loc.street_number  = address_data['house_number']

--- a/lib/geokit/geocoders/opencage.rb
+++ b/lib/geokit/geocoders/opencage.rb
@@ -79,6 +79,7 @@ module Geokit
         loc.zip            = address_data['postcode']
         loc.district       = address_data['city_district']
         loc.district       = address_data['state_district'] if loc.district.nil? && address_data['state_district']
+        loc.neighborhood   = address_data['suburb']
         loc.street_address = "#{address_data['road']} #{address_data['house_number']}".strip if address_data['road']
         loc.street_name    = address_data['road']
         loc.street_number  = address_data['house_number']

--- a/test/test_opencage_geocoder.rb
+++ b/test/test_opencage_geocoder.rb
@@ -76,7 +76,7 @@ class OpencageGeocoderTest < BaseGeocoderTest #:nodoc: all
     assert_equal 'MK', res.country_code
     assert_equal 'opencage', res.provider
 
-    assert_equal 'Бончејца', res.neighborhood
+    assert_equal 'Жабино Маало', res.neighborhood
     assert_equal 'Prilep', res.city
     assert_equal 'Pelagonia Region', res.state
 

--- a/test/test_opencage_geocoder.rb
+++ b/test/test_opencage_geocoder.rb
@@ -53,6 +53,7 @@ class OpencageGeocoderTest < BaseGeocoderTest #:nodoc: all
     assert_equal 'ES', res.country_code
     assert_equal 'opencage', res.provider
 
+    assert_equal 'Chamberí', res.neighborhood
     assert_equal 'Madrid', res.city
     assert_equal 'Community of Madrid', res.state
 
@@ -75,6 +76,7 @@ class OpencageGeocoderTest < BaseGeocoderTest #:nodoc: all
     assert_equal 'MK', res.country_code
     assert_equal 'opencage', res.provider
 
+    assert_equal 'Бончејца', res.neighborhood
     assert_equal 'Prilep', res.city
     assert_equal 'Pelagonia Region', res.state
 


### PR DESCRIPTION
This PR pretends to fill the **neighborhood** loc in **OpenCage** with the `suburb` component type.