### PR TITLE
add first method in GeoLock class

### DIFF
--- a/lib/geokit/geo_loc.rb
+++ b/lib/geokit/geo_loc.rb
@@ -27,7 +27,7 @@ module Geokit
     # attribute if they don't exist
     attr_accessor :state_name, :state_code, :zip, :country_code, :country
     attr_accessor :all, :district, :sub_premise,
-                  :neighborhood
+                  :neighborhood, :first
     attr_writer :state, :full_address, :street_number, :street_name, :formatted_address
     attr_reader :city, :street_address
     # Attributes set upon return from geocoding. Success will be true for
@@ -49,6 +49,7 @@ module Geokit
     # Constructor expects a hash of symbols to correspond with attributes.
     def initialize(h = {})
       @all = [self]
+      @first = self.first
       
       # sanatises the GeoLoc object so that it conforms to []
       h = h.to_hash

--- a/lib/geokit/geo_loc.rb
+++ b/lib/geokit/geo_loc.rb
@@ -49,7 +49,7 @@ module Geokit
     # Constructor expects a hash of symbols to correspond with attributes.
     def initialize(h = {})
       @all = [self]
-      @first = self.first
+      @first = first
       
       # sanatises the GeoLoc object so that it conforms to []
       h = h.to_hash

--- a/test/test_geoloc.rb
+++ b/test/test_geoloc.rb
@@ -92,6 +92,7 @@ class GeoLocTest < Test::Unit::TestCase #:nodoc: all
     assert_equal [
       'city', 'San Francisco',
       'country_code', 'US',
+      'first', '',
       'full_address', '',
       'lat', '',
       'lng', '',

--- a/test/test_geoloc.rb
+++ b/test/test_geoloc.rb
@@ -66,6 +66,10 @@ class GeoLocTest < Test::Unit::TestCase #:nodoc: all
     assert_equal [@loc], @loc.all
   end
 
+  def test_first
+    assert_equal @loc.first, @loc.first
+  end
+
   def test_to_yaml
     @loc.city = 'San Francisco'
     @loc.state_code = 'CA'


### PR DESCRIPTION
# Why

there is add all method but first method is not assigned.

## now

```
Geokit::Geocoders::GoogleGeocoder.api_key = api_key
res = Geokit::Geocoders::GoogleGeocoder.do_reverse_geocode(lonlan)
p res.all.first.full_address
```

## expect

```
Geokit::Geocoders::GoogleGeocoder.api_key = api_key
res = Geokit::Geocoders::GoogleGeocoder.do_reverse_geocode(lonlan)
p res.first.full_address
```