### PR TITLE
Fix Hound-Rubocop integration to use own custom file

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,2 +1,2 @@
-ruby:
+rubocop:
   config_file: .rubocop.yml


### PR DESCRIPTION
As @rafaelpetry said [here](https://github.com/geokit/geokit/pull/229#issuecomment-479695370), it looks like the Hound-Rubocop integration is not properly configured, so we are getting [unexpected offenses](https://github.com/geokit/geokit/pull/229#issuecomment-448144258). Still not sure if it will work, but at least now we're following their [docs](http://help.houndci.com/en/articles/2137566-rubocop) example.