### PR TITLE
Update versions to test in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: ruby
 rvm:
-  - 2.0
-  - 2.1
-  - 2.2
-  - 2.3.0
+  - 2.4
+  - 2.5
+  - 2.6
+  - ruby-head
+allow_failures:
+  - rvm: ruby-head
 script: "bundle exec rake test"
 notifications:
   email:


### PR DESCRIPTION
We're dropping the support to no longer maintained [versions of Ruby](url), starting the tests with the v2.4. Also, we include now testing with the head version of Ruby but allowing failures in this one.