### PR TITLE
Update versions to test in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: ruby
 rvm:
-  - 2.0
-  - 2.1
-  - 2.2
-  - 2.3.0
+  - 2.4
+  - 2.5
+  - 2.6
+  - ruby-head
+allow_failures:
+  - rvm: ruby-head
 script: "bundle exec rake test"
 notifications:
   email:

--- a/geokit.gemspec
+++ b/geokit.gemspec
@@ -33,6 +33,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'test-unit'
   spec.add_development_dependency 'typhoeus' # used in net_adapter
   spec.add_development_dependency 'vcr'
-  # webmock 2 not yet compatible out of the box with VCR
-  spec.add_development_dependency 'webmock', '< 2' # used in vcr
+  spec.add_development_dependency 'webmock'
 end

--- a/test/test_opencage_geocoder.rb
+++ b/test/test_opencage_geocoder.rb
@@ -82,8 +82,8 @@ class OpencageGeocoderTest < BaseGeocoderTest #:nodoc: all
     assert_equal 10, res.precision
     assert_equal true, res.success
 
-    assert_equal "Прилепски Бранители, Prilep, Pelagonia Region, MK", res.full_address
-    assert_equal "Прилепски Бранители", res.street_address
+    assert_equal "Прилепски бранители, Prilep, Pelagonia Region, MK", res.full_address
+    assert_equal "Прилепски бранители", res.street_address
   end
 
   # check if the results are in Spanish if &language=es

--- a/test/test_yandex_geocoder.rb
+++ b/test/test_yandex_geocoder.rb
@@ -34,7 +34,7 @@ class YandexGeocoderTest < BaseGeocoderTest #:nodoc: all
     res = geocode(@full_address)
 
     assert_equal 'yandex', res.provider
-    assert_equal "улица Новый Арбат, 24", res.street_address
+    assert_equal "Улица новый арбат, 24", res.street_address
     assert_equal "Москва", res.city
     assert_equal 55.753083, res.lat
     assert_equal 37.587614, res.lng
@@ -51,8 +51,8 @@ class YandexGeocoderTest < BaseGeocoderTest #:nodoc: all
     res = geocode(region_address)
 
     assert_equal 'yandex', res.provider
-    assert_equal "улица Станиславского, 21", res.street_address
-    assert_equal "Ростов на Дону", res.city
+    assert_equal "Улица станиславского, 21", res.street_address
+    assert_equal "Ростов на дону", res.city
     assert_equal "Ростовская область", res.state
     assert_equal "городской округ Ростов-на-Дону", res.district
     assert_equal 47.21589, res.lat


### PR DESCRIPTION
After the failed attempt with #239, now we did some changes that enable the support to Ruby v2.4, v2.5, and v2.6.

This PR includes:
- Bump to a newer version of `Webmock`
- Fix some expectations failing due to case sensitiveness with non-ASCII characters
- Drop testing on Travis to no longer maintained Ruby versions
- Add testing on Travis to maintained Ruby versions
- Add non-blocking testing on Travis to Ruby head version