### PR TITLE
Make OSMGeocoder host custozimable

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -182,6 +182,9 @@ If you're using this gem by itself, here are the configuration options:
     Geokit::Geocoders::YandexGeocoder.key = ''
     Geokit::Geocoders::MapboxGeocoder.key = 'ACCESS_TOKEN'
     Geokit::Geocoders::OpencageGeocoder.key = 'some_api_key'
+    
+    # OSMGeocoder can receive a custom API server host (if you have your own Nominatim instance running)
+    Geokit::Geocoders::OSMGeocoder.host = 'https://my-custom-nominatim-instance/'
 
     # Geonames has a free service and a premium service, each using a different URL
     # GeonamesGeocoder.premium = true will use http://ws.geonames.net (premium)

--- a/lib/geokit/geocoders/openstreetmap.rb
+++ b/lib/geokit/geocoders/openstreetmap.rb
@@ -2,6 +2,8 @@ module Geokit
   module Geocoders
     # Open Street Map geocoder implementation.
     class OSMGeocoder < Geocoder
+      config :host
+      
       private
 
       # Template method which does the geocode lookup.
@@ -14,8 +16,8 @@ module Geokit
         options_str << generate_param_for_option(:email, options)
 
         address_str = address.is_a?(GeoLoc) ? address.to_geocodeable_s : address
-
-        url = "https://nominatim.openstreetmap.org/search?format=json#{options_str}&addressdetails=1&q=#{Geokit::Inflector.url_escape(address_str)}"
+        request_host = host || 'https://nominatim.openstreetmap.org'
+        url = "#{request_host}/search?format=json#{options_str}&addressdetails=1&q=#{Geokit::Inflector.url_escape(address_str)}"
         process :json, url
       end
 
@@ -29,7 +31,8 @@ module Geokit
         options_str << generate_param_for_option(:osm_type, options)
         options_str << generate_param_for_option(:osm_id, options)
         options_str << generate_param_for_option(:json_callback, options)
-        url = "https://nominatim.openstreetmap.org/reverse?format=json&addressdetails=1#{options_str}"
+        request_host = host || 'https://nominatim.openstreetmap.org'
+        url = "#{request_host}/reverse?format=json&addressdetails=1#{options_str}"
         process :json, url
       end
 


### PR DESCRIPTION
As we had a Nominatim custom instance, we needed to set a custom API server host (other than https://nominatim.openstreetmap.org/).
I also updated readme. Feel free to tell me if I have anything to change in unit testing...