### PR TITLE
Add support for ip-api.com pro.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ Gemfile.lock
 coverage
 .ruby-gemset
 .ruby-version
+.bundle

--- a/README.markdown
+++ b/README.markdown
@@ -175,6 +175,12 @@ If you're using this gem by itself, here are the configuration options:
     # See https://ipstack.com
     Geokit::Geocoders::IpstackGeocoder.api_key = 'API_KEY'
 
+    # This is your api key for ip-api.com.
+    # For the free version (with rate limits), leave api_key unset.
+    # For the pro version, api_key must be set
+    # See https://ip-api.com/
+    Geokit::Geocoders::IpApiGeocoder.api_key = 'API_KEY'
+
     # Most other geocoders need either no setup or a key
     Geokit::Geocoders::BingGeocoder.key = ''
     Geokit::Geocoders::MapQuestGeocoder.key = ''

--- a/fixtures/vcr_cassettes/ip_api_pro_geocode.yml
+++ b/fixtures/vcr_cassettes/ip_api_pro_geocode.yml
@@ -1,0 +1,35 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://pro.ip-api.com/json/74.125.237.209?key=some_api_key
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sat, 23 Sep 2017 04:40:17 GMT
+      Content-Length:
+      - '287'
+    body:
+      encoding: UTF-8
+      string: '{"as":"AS15169 Google Inc.","city":"Mountain View","country":"United
+        States","countryCode":"US","isp":"Google","lat":37.4192,"lon":-122.0574,"org":"Google","query":"74.125.237.209","region":"CA","regionName":"California","status":"success","timezone":"America/Los_Angeles","zip":"94043"}'
+    http_version:
+  recorded_at: Sat, 23 Sep 2017 04:34:33 GMT
+recorded_with: VCR 3.0.3

--- a/lib/geokit/geocoders/ip_api_geocoder.rb
+++ b/lib/geokit/geocoders/ip_api_geocoder.rb
@@ -2,6 +2,8 @@ module Geokit
   module Geocoders
     # Provides geocoding based upon an IP address.  The underlying web service is ip-api.com
     class IpApiGeocoder < BaseIpGeocoder
+      config :api_key
+
       private
 
       def self.do_geocode(ip, _=nil)
@@ -9,7 +11,11 @@ module Geokit
       end
 
       def self.submit_url(ip)
-        "http://ip-api.com/json/#{ip}"
+        if api_key.nil?
+          "http://ip-api.com/json/#{ip}"
+        else
+          "http://pro.ip-api.com/json/#{ip}?key=#{api_key}"
+        end
       end
 
       def self.parse_json(result)

--- a/test/test_ip_api_geocoder.rb
+++ b/test/test_ip_api_geocoder.rb
@@ -20,4 +20,16 @@ class IpApiGeocoderTest < BaseGeocoderTest #:nodoc: all
     assert_equal res.zip, '94043'
     assert_equal res.country_code, 'US'
   end
+
+  def test_ip_api_pro_geocode
+    geocoder_class.api_key = 'some_api_key'
+    url = "http://pro.ip-api.com/json/#{@ip}?key=some_api_key"
+    res = geocode(@ip, :ip_api_pro_geocode)
+    assert_url url
+    assert_equal res.city, 'Mountain View'
+    assert_equal res.state, 'CA'
+    assert_equal res.state_name, 'California'
+    assert_equal res.zip, '94043'
+    assert_equal res.country_code, 'US'
+  end
 end


### PR DESCRIPTION
This adds support for ip-api.com pro. See the below screenshot from their "members" documentation.

<img width="949" alt="Screen Shot 2022-03-21 at 5 36 07 PM" src="https://user-images.githubusercontent.com/885841/159384964-c360591d-4963-4ddc-9428-f1f270967497.png">

It's effectively the same endpoint as the free version, except the `pro` subdomain and the `key=...` param. With the paid plan, there are no additional rate limits.