### PR TITLE
Replace old Ruby versions with newer ones in test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.1.9', '2.2.10', '2.3.7' ]
+        ruby: [ '2.5', '2.6' '2.7', '3.0', '3.1' ]
     name: Test w/ Ruby ${{ matrix.ruby }}
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Add more Ruby versions to test matrix to test against. Do not define patch version to always test against newest one by github action.
Ruby 2.5 and 2.6 are no longer update, but in my opinion a lot of projects still uses them.