### PR TITLE
Remove require of deprecated ubygems.rb file

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,7 @@ require 'bundler/gem_tasks'
 require 'rake/testtask'
 
 task :console do
-  sh "irb -rubygems -I lib -r geokit"
+  sh "irb -I lib -r geokit"
 end
 
 Rake::TestTask.new do |t|


### PR DESCRIPTION
Running this:
```
eric@tux ~/D/geokit (master $)> bundle exec rake console
irb -rubygems -I lib -r geokit
```
Produces this warning:
```
/home/eric/.rubies/ruby-3.1.2/lib/ruby/3.1.0/irb/init.rb:397: warning: LoadError: cannot load such file -- ubygems
Did you mean?  rubygems
irb(main):001:0>
```

The `ubygems.rb` file has been deprecated since Ruby 2.5. Because requiring RubyGems explicitly has been unnecessary since Ruby 1.9, this pull request removes that require.